### PR TITLE
Fix Issues in Platform Swagger Specs

### DIFF
--- a/acpdr/swagger-specs/access-control.yaml
+++ b/acpdr/swagger-specs/access-control.yaml
@@ -1,11 +1,11 @@
 swagger: "2.0"
-info: 
+info:
   version: "1.0"
   title: "Access Control API"
   description: >-
     - Service description:
         - Access Control in Adobe Experience Platform allows IMS Organization administration to assign roles and permissions for various Platform capabilities. The Access Control API provides a public endpoint to retrieve effective policies for a user on given resources within a specified sandbox. All other access control capabilities are provided through the [Adobe Admin Console](https://adminconsole.adobe.com).
-    
+
     - Related documentation:
         - [Access Control documentation](https://adobe.com/go/access-control-overview-en)
 
@@ -13,18 +13,20 @@ info:
         - [Access Control API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Access%20Control%20API.postman_collection.json)
         - [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)
         - [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)
-    
+
     - API paths:
         - PLATFORM Gateway URL: https://<span>platform.adobe.io
         - Base path for this API: /data/foundation/access-control
         - Example of a complete path for making a call to "/acl/effective-policies": https://<span>platform.adobe.io/data/foundation/access-control/acl/effective-policies
-  
+
     - Required headers:
         - All service calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
         - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
         - All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.
 
-tags: 
+basePath: /data/foundation/access-control
+host: platform.adobe.io
+tags:
   - name: "Access Control Policies"
 produces:
   - application/json
@@ -46,7 +48,7 @@ paths:
       responses:
         200:
           description: Successful operation
-          schema: 
+          schema:
             $ref: '#/definitions/referenceResponse'
         400:
           description: Bad request
@@ -66,7 +68,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/json-header'  
+        - $ref: '#/parameters/json-header'
         - in: "body"
           name: "body"
           description: "List of resource urls. Example url : /resource-types/{resourceName} or /permissions/{highLevelPermissionName}"
@@ -75,7 +77,7 @@ paths:
             type: "array"
             items:
               type: "string"
-              enum: 
+              enum:
                 - "/permissions/manage-dataset"
                 - "/resource-types/schema"
                 - "/permissions/manage-schemas"
@@ -103,7 +105,7 @@ paths:
 parameters:
   authorization:
     name: Authorization
-    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ". 
+    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ".
     For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
     required: true
     type: string
@@ -174,7 +176,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
   manageDatasets:
     type: object
@@ -183,7 +185,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -191,7 +193,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -199,7 +201,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -207,7 +209,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -215,7 +217,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
   manageNamespaces:
     type: object
@@ -224,7 +226,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -235,14 +237,14 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
       profile-configs:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -250,7 +252,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -258,7 +260,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -266,19 +268,19 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       segment-jobs:
         type: array
         items:
           type: string
-        example: 
+        example:
           - write
       segments:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -289,7 +291,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -300,7 +302,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -308,7 +310,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -316,7 +318,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -324,7 +326,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -332,7 +334,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -340,7 +342,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -351,7 +353,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
   viewDatasets:
@@ -361,31 +363,31 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       datasets:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       datasets-data:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       dule-label:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       schemas:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
   viewNamespaces:
     type: object
@@ -394,7 +396,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
   viewMonitoring:
     type: object
@@ -403,19 +405,19 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       datasets-data:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       monitoring:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
   viewProfiles:
     type: object
@@ -424,19 +426,19 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       profile-configs:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       profile-datasets:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -444,19 +446,19 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       schemas:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       segments:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
   viewSandboxes:
     type: object
@@ -465,7 +467,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
   viewSchemas:
     type: object
@@ -474,37 +476,37 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       data-types:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       identity-descriptor:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       mixins:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       relationship-descriptor:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
       schemas:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
   resourceTypes:
     type: object
@@ -513,7 +515,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -521,7 +523,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -529,7 +531,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -537,7 +539,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -545,7 +547,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -553,7 +555,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -561,7 +563,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -569,7 +571,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -577,7 +579,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -585,7 +587,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -593,7 +595,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -601,7 +603,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -609,7 +611,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -617,7 +619,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -625,7 +627,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -633,7 +635,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -641,7 +643,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -649,7 +651,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete
@@ -657,7 +659,7 @@ definitions:
         type: array
         items:
           type: string
-        example: 
+        example:
           - read
           - write
           - delete

--- a/acpdr/swagger-specs/access-control.yaml
+++ b/acpdr/swagger-specs/access-control.yaml
@@ -46,13 +46,21 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: Successful operation
           schema:
             $ref: '#/definitions/referenceResponse'
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad request
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal server error
   /acl/effective-policies:
     post:
@@ -82,6 +90,10 @@ paths:
                 - "/resource-types/schema"
                 - "/permissions/manage-schemas"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "Successful operation"
           schema:
@@ -102,11 +114,12 @@ paths:
                     "delete",
                     "*"
                   ]
+
 parameters:
   authorization:
     name: Authorization
     description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ".
-    For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
+      For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
     required: true
     type: string
     in: header
@@ -135,6 +148,33 @@ parameters:
     type: string
     in: header
 definitions:
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
   referenceResponse:
     type: object
     properties:

--- a/acpdr/swagger-specs/audit-query.yaml
+++ b/acpdr/swagger-specs/audit-query.yaml
@@ -59,13 +59,21 @@ paths:
           required: false
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of audit events that match the request query.
           schema:
             $ref: "#/definitions/CollectionModel"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was malformed. Ensure that you are including all required headers before trying again.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource was not found.
   "/audit/export":
     get:
@@ -83,19 +91,27 @@ paths:
         - $ref: '#/parameters/x-request-id'
         - $ref: '#/parameters/property'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: The request was successful but no results were found.
         '307':
           description: The request was successful and the results have been generated into a CSV file for export. A link to the export file is provided in the `Location` response header.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was malformed. Ensure that you are including all required headers before trying again.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource was not found.
 parameters:
   authorization:
     name: Authorization
-    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ". 
-    For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
+    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ".
+      For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
     required: true
     type: string
     in: header
@@ -122,8 +138,8 @@ parameters:
     in: query
     description: >-
       You can filter list results by including a `property` query parameter. The value must be an array that contains one or more of a comma-separated list of properties. For example: `?property=action==create,assetType==Sandbox`.
-      
-      
+
+
       The properties that can be used for filtering are `timestamp`, `status`, `action`, `user`, and `assetType`.
     required: false
     type: array
@@ -137,6 +153,33 @@ parameters:
     description: A tracing ID associated with the request. If one is not provided on the request, the server generates one automatically.
     required: false
 definitions:
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
   AbstractAuditLog:
     type: object
     properties:

--- a/acpdr/swagger-specs/catalog.yaml
+++ b/acpdr/swagger-specs/catalog.yaml
@@ -173,6 +173,10 @@ paths:
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/properties'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A list of the batch responses is returned.
           schema:
@@ -267,15 +271,22 @@ paths:
                   }
               }
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The batch responses were not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     post:
       tags:
         - Batches
@@ -295,6 +306,10 @@ paths:
             $ref: '#/definitions/batchRequest'
         - $ref: '#/parameters/json-header'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: 'Array[ @/batches/batchId ]'
           schema:
@@ -306,13 +321,18 @@ paths:
               type: string
               description: The URI of the newly created batch.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The batch is invalid.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
   '/batches/uniques/{FIELD}':
     parameters:
       - name: FIELD
@@ -453,6 +473,10 @@ paths:
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/properties'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A list of unique values for a batch.
           schema:
@@ -463,15 +487,22 @@ paths:
             application/json:
               ["5911f88ae2f4bf657c5a8cb5", "5911f88ae2f4bf657c5a8cb4", "5911f88ae2f4bf657c5a8cb3"]
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request has been submitted.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The batch is not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
   '/batches/{BATCH_ID}':
     parameters:
       - name: BATCH_ID
@@ -501,6 +532,10 @@ paths:
           type: boolean
           in: query
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The batch object for the specified batch ID is returned.
           schema:
@@ -595,15 +630,22 @@ paths:
                   }
               }
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The specified batch was not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     post:
       tags:
         - Batches
@@ -623,6 +665,10 @@ paths:
             $ref: '#/definitions/batchRequest'
         - $ref: '#/parameters/json-header'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: 'Array[ @/batches/batchId ]'
           schema:
@@ -634,13 +680,18 @@ paths:
               type: string
               description: The URI of the newly created resource.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     put:
       tags:
         - Batches
@@ -662,6 +713,10 @@ paths:
             $ref: '#/definitions/batchRequest'
         - $ref: '#/parameters/json-header'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: 'Array[ @/batches/batchId ]'
           schema:
@@ -669,15 +724,22 @@ paths:
             items:
               type: string
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     patch:
       tags:
         - Batches
@@ -699,6 +761,10 @@ paths:
         - $ref: '#/parameters/json-header'
         - $ref: '#/parameters/if-none-match'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: 'Array[ @/batches/batchId ]'
           schema:
@@ -706,15 +772,22 @@ paths:
             items:
               type: string
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The specified batch was not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     delete:
       tags:
         - Batches
@@ -726,6 +799,10 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: 'Array[ @/batches/batchId ]'
           schema:
@@ -733,15 +810,22 @@ paths:
             items:
               type: string
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The batch was not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
   /dataSets:
     parameters:
       - $ref: '#/parameters/authorization'
@@ -800,6 +884,10 @@ paths:
         - $ref: '#/parameters/properties'
         - $ref: '#/parameters/tags'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A list of datasets is returned.
           schema:
@@ -843,15 +931,22 @@ paths:
                   }
               }
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The datasets are not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     post:
       tags:
         - Datasets
@@ -871,6 +966,10 @@ paths:
             $ref: '#/definitions/dataSetRequest'
         - $ref: '#/parameters/json-header'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: The dataset has been successfully created.
           schema:
@@ -882,13 +981,18 @@ paths:
               type: string
               description: The URI of the newly created resource
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
   '/dataSets/{DATASET_ID}':
     parameters:
       - name: DATASET_ID
@@ -917,6 +1021,10 @@ paths:
           type: string
           required: false
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The dataset for the specified dataset ID is returned.
           schema:
@@ -961,15 +1069,22 @@ paths:
                   }
               }
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The dataset was not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     put:
       tags:
         - Datasets
@@ -990,6 +1105,10 @@ paths:
             $ref: '#/definitions/dataSetRequest'
         - $ref: '#/parameters/json-header'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: 'Array[ @/dataSets/dataSetId ]'
           schema:
@@ -997,13 +1116,18 @@ paths:
             items:
               type: string
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     patch:
       tags:
         - Datasets
@@ -1024,6 +1148,10 @@ paths:
             $ref: '#/definitions/dataSetRequest'
         - $ref: '#/parameters/json-header'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: 'Array[ @/dataSets/dataSetId ]'
           schema:
@@ -1031,15 +1159,22 @@ paths:
             items:
               type: string
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     delete:
       tags:
         - Datasets
@@ -1050,6 +1185,10 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: 'Array[ @/dataSets/dataSetId ]'
           schema:
@@ -1057,15 +1196,22 @@ paths:
             items:
               type: string
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
   '/dataSets/{id}/credentials':
     parameters:
       - $ref: '#/parameters/id'
@@ -1090,18 +1236,27 @@ paths:
           in: query
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Credential object given dataSet.
           schema:
             $ref: '#/definitions/dataSetCredentials'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
   '/':
     get:
       tags:
@@ -1117,16 +1272,23 @@ paths:
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/properties'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: serviceResources
           schema:
             $ref: '#/definitions/serviceResources'
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
     post:
       tags:
         - Batched requests
@@ -1148,6 +1310,10 @@ paths:
               $ref: '#/definitions/resourceItem'
         - $ref: '#/parameters/json-header'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: 'Array[ @/resource/resourceId ]'
           schema:
@@ -1159,13 +1325,18 @@ paths:
               type: string
               description: The URI of the newly created resource
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
   '/tags/{tagNamespace}':
     parameters:
       - $ref: '#/parameters/tagNamespace'
@@ -1182,6 +1353,10 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns aggregated tagValues for given namespace.
           schema:
@@ -1197,13 +1372,18 @@ paths:
                 "adobe/pqs/databases": ["baz", "bat", "foo", "bar"]
               }
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: A bad request.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: not found
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
-        default:
-          description: An unexpected error has ocurred.
+
 parameters:
   x-sandbox-name:
     name: x-sandbox-name
@@ -1418,6 +1598,33 @@ parameters:
       - batch
     required: true
 definitions:
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
   batchRequest:
     type: object
     properties:
@@ -2633,3 +2840,30 @@ definitions:
           type: string
         description: >-
           - Array of aggregated values for input tagNamespace
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true

--- a/acpdr/swagger-specs/catalog.yaml
+++ b/acpdr/swagger-specs/catalog.yaml
@@ -2299,6 +2299,10 @@ definitions:
         type: string
         description: >-
           - The ID for associated DataSet view.
+      id:
+        type: string
+        description: >-
+          - The ID for the DataSet.
       observableSchema:
         type: object
         description: >-

--- a/acpdr/swagger-specs/catalog.yaml
+++ b/acpdr/swagger-specs/catalog.yaml
@@ -2299,10 +2299,6 @@ definitions:
         type: string
         description: >-
           - The ID for associated DataSet view.
-      id:
-        type: string
-        description: >-
-          - The ID for the DataSet.
       observableSchema:
         type: object
         description: >-

--- a/acpdr/swagger-specs/catalog.yaml
+++ b/acpdr/swagger-specs/catalog.yaml
@@ -5,9 +5,9 @@ info:
   description: >-
     - Service description:
         - Catalog is the system of record for data location and lineage within Adobe Experience Platform. Catalog Service does not contain the actual files or directories that contain the data. Instead, it holds the metadata and description of those files and directories.
-    
+
         - Catalog acts as a metadata store or "catalog" where you can find information about your data within Experience Platform.
-  
+
         - You can use Catalog to answer the following questions: Where is my data located? At what stage of processing is this data? What systems or processes have acted on my data? What errors occurred during processing? If successful, how much data was processed?
 
 
@@ -37,10 +37,10 @@ tags:
   - name: Batched requests
     description: Batched requests allow users to supply an array of objects in the request payload, representing what would normally be individual requests.
   - name: Datasets
-    description: Datasets are the building blocks for data transformation and tracking in Catalog Service. 
+    description: Datasets are the building blocks for data transformation and tracking in Catalog Service.
   - name: Tags
-    description: Tags are used to attach information to an object and then be used later to retrieve the object. 
-  
+    description: Tags are used to attach information to an object and then be used later to retrieve the object.
+
 produces:
   - application/json
 paths:
@@ -316,8 +316,8 @@ paths:
   '/batches/uniques/{FIELD}':
     parameters:
       - name: FIELD
-        description: >- 
-          - Field to get unique values for. **Note:** This endpoint will be deprecated soon. 
+        description: >-
+          - Field to get unique values for. **Note:** This endpoint will be deprecated soon.
         required: true
         type: string
         in: path
@@ -431,7 +431,7 @@ paths:
           type: string
           in: query
         - name: connector
-          description: >- 
+          description: >-
             - Filter on the ID of the connector.
           required: false
           type: string
@@ -478,7 +478,7 @@ paths:
         description: >-
           - The ID of the batch you are performing the operation on.
         in: path
-        required: true 
+        required: true
         type: string
       - $ref: '#/parameters/id'
       - $ref: '#/parameters/authorization'
@@ -790,7 +790,7 @@ paths:
         - name: enableErrorDiagnostics
           description: >-
             - A field that provides the ability to opt in to generating diagnostic files for the errors while ingesting data.
-          required: false 
+          required: false
           type: boolean
           in: query
         - $ref: '#/parameters/orderBy'
@@ -894,7 +894,7 @@ paths:
       - name: DATASET_ID
         description: >-
           - The ID of the dataset.
-        required: true 
+        required: true
         type: string
         in: path
       - $ref: '#/parameters/authorization'
@@ -1058,6 +1058,8 @@ paths:
               type: string
         '400':
           description: A bad request.
+        '404':
+          description: Not found.
         '403':
           description: Access is forbidden.
         '500':
@@ -1100,7 +1102,7 @@ paths:
           description: An internal server error has ocurred.
         default:
           description: An unexpected error has ocurred.
-  '/':        
+  '/':
     get:
       tags:
         - Batched requests
@@ -1137,7 +1139,7 @@ paths:
       parameters:
         - name: resources
           description: >-
-            The relative path of the resource. 
+            The relative path of the resource.
           required: true
           in: body
           schema:
@@ -1212,7 +1214,7 @@ parameters:
     in: header
   schemaRef:
       name: id
-      description: >- 
+      description: >-
         - The schema in URI (https://ns.adobe.com/xdm/context/profile, https://ns.adobe.com/customer/imsOrg/extensionNS/objectName) or meta:altId (_xdm.context.profile, _customer.extensionNS.objectName) or original XDM ID format (context/profile, _customer/extensionNS/objectName).
       required: false
       in: query
@@ -1289,7 +1291,7 @@ parameters:
     format: int64
   createdBefore:
     name: createdBefore
-    description: >- 
+    description: >-
       - Exclusively filter records created before this timestamp.
     required: false
     in: query
@@ -1305,14 +1307,14 @@ parameters:
     in: query
   createdClient:
     name: createdClient
-    description: >- 
+    description: >-
       - Filter by the ID of the IMS client that created this object.
     required: false
     type: string
     in: query
   createdUser:
     name: createdUser
-    description: >- 
+    description: >-
       - Filter by the ID of the user who created this object.
     required: false
     type: string
@@ -1443,7 +1445,7 @@ definitions:
             type: array
             items:
               type: string
-              description: >- 
+              description: >-
                 - One or more Batch Identifiers that this replay is replacing.
           reason:
             type: string
@@ -1645,7 +1647,7 @@ definitions:
       - Metadata describing the INGEST format of the data being loaded (e.g. Parquet, CSV, JSON).
     properties:
       format:
-        description: >- 
+        description: >-
           - The file format for data being submitted in the Batch.
         enum:
           - "csv"
@@ -1660,7 +1662,7 @@ definitions:
           - Character used to separate fields.
         type: string
       quote:
-        description: >- 
+        description: >-
           - Character used to quote fields that contains spaces, tabs, and/or delimiter characters.
         type: string
       escape:
@@ -1672,7 +1674,7 @@ definitions:
           - Character/string used to indicate a null value. Any value matching this string will be set as nulls in Data Lake.
         type: string
       header:
-        description: >- 
+        description: >-
           - True if input files are expected to have a header row.
         type: string
       charset:
@@ -1708,12 +1710,12 @@ definitions:
         readOnly: true
       createdClient:
         type: string
-        description: >- 
+        description: >-
           - The ID of the IMS client that created this Batch.
         readOnly: true
       createdUser:
         type: string
-        description: >- 
+        description: >-
           - The ID of the user who created this object.
         readOnly: true
       updatedUser:
@@ -1792,7 +1794,7 @@ definitions:
           - deleted
       failedBatchLocation:
         type: string
-        description: >- 
+        description: >-
           - When a batch status is failed, the URI at which to retrieve the batch
       recordCount:
         type: integer
@@ -1915,7 +1917,7 @@ definitions:
           failedRowCount:
             type: integer
             format: int64
-            description: >- 
+            description: >-
               - Rows that failed processing.
           rowCount:
             type: integer
@@ -1942,7 +1944,7 @@ definitions:
           - observableSchema stores a JSON Schema object that is a valid subset (including the null case) of the XDM model specified by `schemaRef`.
       requestStartDate:
         type: string
-        description: >- 
+        description: >-
           - The oldest date and the time, when the data was last ingested
       fields:
         type: array
@@ -1957,14 +1959,14 @@ definitions:
         readOnly: true
       fileDescription:
         type: object
-        description: >- 
+        description: >-
           - Metadata describing the dataset files associated with this DataSetView.
         properties:
           format:
             $ref: '#/definitions/format'
           delimiters:
             type: array
-            description: >- 
+            description: >-
               - Characters used to separate fields.
             items:
               type: string
@@ -1989,7 +1991,7 @@ definitions:
             description: ''
           charset:
             type: string
-            description: >- 
+            description: >-
               - The character encoding of the files.
             enum:
               - US-ASCII
@@ -1998,7 +2000,7 @@ definitions:
               - ''
       schema:
         type: string
-        description: >- 
+        description: >-
           - This is the uri for the XDM model
       schemaMetadata:
         $ref: '#/definitions/schemaMetadata'
@@ -2006,7 +2008,7 @@ definitions:
         $ref: '#/definitions/schemaRef'
       dataSourceId:
         type: integer
-        description: >- 
+        description: >-
           - The Id of the datasource. It must be unique, along with it''s name.
   dataSetResponse:
     type: object
@@ -2034,7 +2036,7 @@ definitions:
           - A descriptive, human-readable name for this DataSet.
       description:
         type: string
-        description: >-   
+        description: >-
           - A longer text description of the DataSet.
       created:
         type: integer
@@ -2050,7 +2052,7 @@ definitions:
         readOnly: true
       createdClient:
         type: string
-        description: >- 
+        description: >-
           - The ID of the IMS client that created this Batch.
         readOnly: true
       createdUser:
@@ -2096,7 +2098,7 @@ definitions:
           - observableSchema stores a JSON Schema object that is a valid subset (including the null case) of the XDM model specified by `schemaRef`.
       requestStartDate:
         type: string
-        description: >- 
+        description: >-
           - The oldest date and the time, when the data was last ingested.
       fields:
         type: array
@@ -2111,7 +2113,7 @@ definitions:
         readOnly: true
       fileDescription:
         type: object
-        description: >- 
+        description: >-
           - Metadata describing the dataset files associated with this DataSetView.
         properties:
           format:
@@ -2427,7 +2429,7 @@ definitions:
                 - Marks this field as a join key into other datasets.
       delta:
         type: array
-        description: >- 
+        description: >-
           - The presence of this attribute on a field indicates that it is used in the origin system for retrieving 'deltas' of data.
         items:
           type: object
@@ -2446,7 +2448,7 @@ definitions:
                 - The timezone that the data uses in the origin system, uses the format from IANA in the tz_database.
       contentAttributes:
         type: array
-        description: >- 
+        description: >-
           - This attribute gives information the columns. For eg. if the field is hidden, temporarily empty etc.
         items:
           type: object
@@ -2461,7 +2463,7 @@ definitions:
                 - This field stores the information about the specific column for eg.EMPTY_PERMANENT.
   credentials:
     type: object
-    description: >- 
+    description: >-
       - Credentials.
     properties:
       clientKey:

--- a/acpdr/swagger-specs/data-access-api.yaml
+++ b/acpdr/swagger-specs/data-access-api.yaml
@@ -23,7 +23,7 @@ info:
       - PLATFORM Gateway URL: https://<span>platform.adobe.io/
       - Base path for this API: /data/foundation/export
       - Example of a complete path: https://<span>platform.adobe.io/data/foundation/export/batches/{batchId}/files
-    
+
     - Required headers:
       - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
       - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
@@ -71,13 +71,21 @@ paths:
       produces:
       - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The request was successful."
           schema:
             $ref: "#/definitions/dataSetFiles"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   /batches/{batchId}/failed:
     parameters:
@@ -114,13 +122,21 @@ paths:
       produces:
       - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The request was successful."
           schema:
             $ref: "#/definitions/files"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   /batches/{batchId}/meta:
     parameters:
@@ -135,7 +151,7 @@ paths:
       - $ref: '#/parameters/x-sandbox-name'
       - name: "start"
         in: "query"
-        required: false 
+        required: false
         type: "string"
         description: "A paging parameter to specify the start of a new page. For example: `start=1`"
       - name: "limit"
@@ -149,22 +165,32 @@ paths:
         type: "string"
         description: "The full name of the file. The contents of the file would be downloaded if this parameter is provided. For example: `path=row_error_samples.json`\nPossible values for this query include the following: \n - `row_errors`\n - `input_files`\n - `row_errors_sample.json`"
     get:
-      tags: 
+      tags:
       - Data Access
       summary: "Get the meta files under a batch."
       description: "Lists files under a batch's meta directory or download a specific file under it. The files under a batch's meta directory may include the following: \n - row_errors: A directory containing 0 or more files with parsing, conversion, and/or validation errors found at the row level.\n - input_files: A directory containing metadata for 1 or more input files submitted with the batch.\n - row_errors_sample.json: A root level file containing the sampled set of row errors for the UX."
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The request was successful."
           schema:
             $ref: "#/definitions/metadata"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The path is not found."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal service error has ocurred."
   /files/{dataSetFileId}:
     parameters:
@@ -189,6 +215,10 @@ paths:
         required: true
         description: "The full name of the file identified. For example: `path=profiles.csv`"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The request was successful."
           headers:
@@ -202,10 +232,16 @@ paths:
               description: "The size of the file in bytes."
               type: "integer"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The dataset file was not found."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     get:
       operationId: "getDatasetFileData"
@@ -239,6 +275,10 @@ paths:
       - application/json
       - application/octet-stream
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The request has succeeded."
           schema:
@@ -254,10 +294,16 @@ paths:
               type: "integer"
 
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The requested file was not found."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   /datasets/{id}/preview:
     parameters:
@@ -278,17 +324,26 @@ paths:
       produces:
       - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The request has succeeded."
           schema:
             $ref: "#/definitions/preview"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The requested dataset was not found."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
-
 parameters:
   authorization:
     name: Authorization
@@ -316,7 +371,33 @@ parameters:
     in: header
 
 definitions:
-
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
   metadata:
     type: "object"
     properties:

--- a/acpdr/swagger-specs/data-prep.yaml
+++ b/acpdr/swagger-specs/data-prep.yaml
@@ -3,7 +3,7 @@ info:
   description: >-
     - Service description:
       - Data Prep allows data engineers to map, transform, and validate data to and from Experience Data Model (XDM). The Data Prep API lets you programatically create mapping sets and functions, allowing you to transform your data between source and destination schemas.
-    
+
     - Related documentation:
       - [Data Prep documentation](https://experienceleague.adobe.com/docs/experience-platform/data-prep/home.html)
 
@@ -11,7 +11,7 @@ info:
       - Platform Gateway URL: https://<spam>platform.adobe.io/
       - Base path for this API: /data/foundation/conversation
       - Example of a complete path: https://<span>platform.adobe.io/data/foundation/conversion/languages/el/functions
-    
+
     - Required headers:
         - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.com/go/platform-api-authentication-en).
         - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
@@ -49,6 +49,10 @@ paths:
           schema:
             "$ref": "#/definitions/ValidationRequest"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the validation status of the expression.
           schema:
@@ -60,12 +64,20 @@ paths:
                 "error": "none"
               }
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid expression was posted.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
   "/languages/el/functions":
@@ -82,6 +94,10 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of all the available mapping-set functions. **Note:** The following response has been truncated for space.
           schema:
@@ -125,12 +141,20 @@ paths:
                   }
               ]
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid request was posted.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
   "/languages/el/operators":
@@ -147,6 +171,10 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of all the valid operators. **Note:** The following response has been truncated for space.
           schema:
@@ -193,12 +221,20 @@ paths:
                   }
               ]
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid request was posted.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
   "/mappingSets":
@@ -246,20 +282,32 @@ paths:
         - name: expandSchema
           in: query
           description: Determines whether the full output schema is returned as part of the response.
-          required: false 
+          required: false
           type: boolean
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of all the mapping sets.
           schema:
             "$ref": "#/definitions/MapperSetPage"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid request was posted.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
     post:
@@ -284,12 +332,16 @@ paths:
           schema:
             "$ref": "#/definitions/MappingSet"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns information about your newly created mapping set.
           schema:
             "$ref": "#/definitions/SimpleRepresentation"
           examples:
-            application/json: 
+            application/json:
               {
                 "id": "e7c80e4c0d8f4a98a7d400b4e178b635",
                 "version": 0,
@@ -299,12 +351,20 @@ paths:
                 "modifiedBy": "{MODIFIED_BY}"
               }
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid mapping set was requested.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
   "/mappingSets/validate":
@@ -330,6 +390,10 @@ paths:
           schema:
             "$ref": "#/definitions/MappingSet"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the validation information for the proposed mapping set.
           schema:
@@ -353,12 +417,20 @@ paths:
                 ]
             }
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid mapping set was requested.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
   "/mappingSets/preview":
@@ -384,17 +456,29 @@ paths:
           schema:
             "$ref": "#/definitions/PreviewRequest"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a preview of your mapped data.
           schema:
             "$ref": "#/definitions/PreviewResponse"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid request was sent.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
   "/mappingSets/{MAPPING_SET_ID}":
@@ -430,17 +514,29 @@ paths:
           default: 0
           format: int32
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns information about the specified mapping set.
           schema:
             "$ref": "#/definitions/MappingSet"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid request was sent.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
     put:
@@ -470,17 +566,29 @@ paths:
           schema:
             "$ref": "#/definitions/MappingSet"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns detailed information about your newly updated mapping set.
           schema:
             "$ref": "#/definitions/MappingSet"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid request was sent.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
   "/mappingSets/{MAPPING_SET_ID}/mappings":
@@ -494,7 +602,7 @@ paths:
       parameters:
         - name: MAPPING_SET_ID
           in: path
-          description: The ID of the mapping set you are retrieving mappings for. 
+          description: The ID of the mapping set you are retrieving mappings for.
           required: true
           type: string
           x-example: 7c80e4c0d8f4a98a7d400b4e178b635
@@ -503,17 +611,29 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns all the mappings for the specified mapping set.
           schema:
             "$ref": "#/definitions/MappingOperation"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid request was sent.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
   "/mappingSets/{MAPPING_SET_ID}/mappings/{MAPPING_ID}":
@@ -542,17 +662,29 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns information about the specific mapping.
           schema:
             "$ref": "#/definitions/MappingOperation"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid request was sent.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request was unauthorized. Please provide a valid authorization header and try again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
       deprecated: false
 definitions:
@@ -687,7 +819,7 @@ definitions:
         format: date-time
       xdmVersion:
         type: string
-    title: JsonSchema    
+    title: JsonSchema
   SchemaRepresentation:
     type: object
     properties:
@@ -881,7 +1013,7 @@ definitions:
       tags:
         type: array
         items:
-          "$ref": "#/definitions/Tags"        
+          "$ref": "#/definitions/Tags"
     title: MappingSet
     example:
       mappings:
@@ -903,7 +1035,7 @@ definitions:
             "source": "lastName",
             "destination": "person.name.lastName"
         }]
-      outputSchema: 
+      outputSchema:
         {
           "schemaRef": {
             "id": "https://ns.adobe.com/{TENANT_ID}/schemas/89abc189258b1cb1a816d8f2b2341a6d98000ed8f4008305",
@@ -937,7 +1069,7 @@ definitions:
       expressionAttributes:
         type: array
         items:
-          type: string        
+          type: string
       version:
         type: integer
         format: int32
@@ -956,8 +1088,8 @@ definitions:
       sourceType: "text/x.schema-path"
       source: "firstName"
       destination: "person.name.firstName"
-      identity: false 
-      primaryIdentity: false 
+      identity: false
+      primaryIdentity: false
       matchScore: 0.0
       functionVersion: 1
       sourceAttribute: "firstName"
@@ -1035,7 +1167,7 @@ definitions:
         items:
           "$ref": "#/definitions/MappingSet"
     title: MapperSetPage
-    example: 
+    example:
       data:
         {
           "id": "428beb15b4864daaaa9dc3f005448005",
@@ -1097,6 +1229,33 @@ definitions:
         items:
           type: string
     title: Tags
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
 parameters:
   authorization:
     name: Authorization
@@ -1107,9 +1266,9 @@ parameters:
     in: header
   content-type:
     name: Content-Type
-    description: >- 
+    description: >-
       The type of content being sent in the body of the request. This value generally is `application/json`.
-    required: true 
+    required: true
     type: string
     in: header
   x-gw-ims-org-id:

--- a/acpdr/swagger-specs/dataset-service.yaml
+++ b/acpdr/swagger-specs/dataset-service.yaml
@@ -43,6 +43,10 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The data usage labels for the specified dataset were retrieved.
           schema:
@@ -56,7 +60,7 @@ paths:
         - Datasets
       summary: Add data usage labels to a specified dataset, and/or specific fields within that dataset.
       operationId: postDatasetLabels
-      produces: 
+      produces:
         - application/json
       parameters:
         - $ref: '#/parameters/DATASET_ID'
@@ -69,6 +73,10 @@ paths:
           schema:
             $ref: '#/definitions/DULELabel'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: The data usage labels were successfully added.
           schema:
@@ -101,11 +109,17 @@ paths:
           schema:
             $ref: '#/definitions/DULELabel'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
             description: "The data usage labels were successfully updated."
             schema:
               $ref: '#/definitions/DULELabel'
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
             description: "The labels entity was not found."
             schema:
               $ref: '#/definitions/NotFoundError'
@@ -130,9 +144,15 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: "The data usage labels were successfully removed."
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The data usage labels cannot be deleted."
 parameters:
   x-sandbox-name:
@@ -180,7 +200,7 @@ parameters:
     name: If-Match
     in: header
     required: true
-    description: >- 
+    description: >-
       The version of the dataset entity to compare against. As a requirement for all PUT and DELETE requests for dataset labels, the call will only update the dataset entity if the "If-Match" string matches that of the "etag" header that is returned in all responses from the Dataset Service API.
     type: string
 definitions:
@@ -206,7 +226,7 @@ definitions:
               option:
                 type: object
                 properties:
-                  id: 
+                  id:
                     type: string
                     example: "https://ns.adobe.com/{TENANT_ID}/schemas/{SCHEMA_ID}"
                   contentType:
@@ -280,7 +300,7 @@ definitions:
         example: "/dulepolicy/marketingActions/core/g72cbgy644bsgc3becbba1e197fa25c1e/constraints"
       entities:
         type: array
-        items: 
+        items:
           $ref: '#/definitions/DULELabel'
       violatedPolicies:
         type: array
@@ -314,7 +334,7 @@ definitions:
         example: "AND"
       operands:
         type: array
-        items: 
+        items:
           type: string
           example: [{ "label": "C1" }, { "label": "C2"}]
       imsOrg:
@@ -357,3 +377,30 @@ definitions:
           href:
             type: string
             example: "https://platform.adobe.io/data/foundation/dulepolicy/policies/custom/5db3393907d49f198b8f0e6a"
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true

--- a/acpdr/swagger-specs/dule-policy-service.yaml
+++ b/acpdr/swagger-specs/dule-policy-service.yaml
@@ -60,6 +60,10 @@ paths:
         - $ref: '#/parameters/startQuery'
         - $ref: '#/parameters/limitQuery'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of core labels.
           schema:
@@ -77,6 +81,10 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the retrieved core label.
           schema:
@@ -101,6 +109,10 @@ paths:
         - $ref: '#/parameters/startQuery'
         - $ref: '#/parameters/limitQuery'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A list of custom labels.
           schema:
@@ -123,11 +135,17 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns the details of the retrieved custom label.
           schema:
             $ref: '#/definitions/CustomLabelsResponse'
         '404':
+
           description: No custom label was found for the given name.
           schema:
             $ref: '#/definitions/CustomNotFoundError'
@@ -149,6 +167,11 @@ paths:
           schema:
             $ref: '#/definitions/LabelsRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: If the label name indicated by the request path exists in the system, the existing entity is updated. A successful response returns details of the label, indicating the label was successfully updated.
           schema:
@@ -158,6 +181,7 @@ paths:
           schema:
             $ref: '#/definitions/CustomLabelsResponse'
         '400':
+
           description: >-
             There was an error regarding the fields sent in the request payload. This occurs if either of the required fields ("name" or "category") are missing or malformed.
           schema:
@@ -180,6 +204,11 @@ paths:
       tags:
         - Policies
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns all core policies.
           schema:
@@ -201,11 +230,17 @@ paths:
       tags:
         - Policies
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns the details of the retrieved policy.
           schema:
             $ref: '#/definitions/CorePolicyResponse'
         '404':
+
           description: No policy was found for the given ID.
           schema:
             $ref: '#/definitions/CorePolicyNotFound'
@@ -227,6 +262,11 @@ paths:
         - $ref: '#/parameters/labelsQuery'
         - $ref: '#/parameters/marketingActionQuery'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns a list of custom policies.
           schema:
@@ -249,11 +289,17 @@ paths:
           schema:
             $ref: '#/definitions/PolicyRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '201':
           description: A successful response returns the details of newly created policy.
           schema:
             $ref: '#/definitions/CustomPolicyResponse'
         '400':
+
           description: One or more of the required fields in the request body were either missing or malformed.
           schema:
             $ref: '#/definitions/CreatePolicyError'
@@ -274,11 +320,17 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns details of the retrieved custom policy.
           schema:
             $ref: '#/definitions/PolicyResponse'
         '404':
+
           description: No policy was found for the given ID.
           schema:
             $ref: '#/definitions/CustomPolicyNotFound'
@@ -305,15 +357,22 @@ paths:
           schema:
             $ref: '#/definitions/PolicyRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns details of the updated policy.
           schema:
             $ref: '#/definitions/PolicyResponse'
         '400':
+
           description: One or more of the required fields in the request body were either missing or malformed.
           schema:
             $ref: '#/definitions/CreatePolicyError'
         '404':
+
           description: No policy was found for the given ID.
           schema:
             $ref: '#/definitions/CustomPolicyNotFound'
@@ -340,15 +399,22 @@ paths:
           schema:
             $ref: '#/definitions/PolicyPatchRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns the details of updated policy.
           schema:
             $ref: '#/definitions/PolicyPatchResponse'
         '400':
+
           description: One or more of the required fields in the request body were either missing or malformed.
           schema:
             $ref: '#/definitions/CreatePolicyError'
         '404':
+
           description: No policy was found for the given ID.
           schema:
             $ref: '#/definitions/CustomPolicyNotFound'
@@ -368,9 +434,15 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns HTTP Status 200 (OK) with an empty body, indicating the entity was deleted.
         '404':
+
           description: No policy was found for the given ID.
           schema:
             $ref: '#/definitions/CustomPolicyNotFound'
@@ -390,6 +462,11 @@ paths:
         - $ref: '#/parameters/startQuery'
         - $ref: '#/parameters/limitQuery'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns a list of core marketing actions.
           schema:
@@ -411,11 +488,17 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns the details of the retrieved marketing action.
           schema:
             $ref: '#/definitions/CoreMarketingActionResponse'
         '404':
+
           description: No marketing action was found for the given name.
           schema:
             $ref: '#/definitions/CoreMarketingActionNotFound'
@@ -424,8 +507,8 @@ paths:
       summary: Evaluate a core marketing action for policy violations based on data usage labels.
       description: >-
         This call returns a set of constraints that would govern an attempt to perform the given marketing action on a hypothetical source of data containing specific data usage labels.
-        
-        
+
+
         You can also evaluate a marketing action based on the labels contained in an actual dataset in your data stores. See the POST method for this endpoint for more information.
       operationId: getCoreMarketingActionConstraints
       tags:
@@ -443,12 +526,18 @@ paths:
         - $ref: '#/parameters/labelsConstraintsQuery'
         - $ref: '#/parameters/includeDraftConstraintsQuery'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: >-
             A successful response returns the constraints on attempting to perform this marketing action on data bearing the given set of data usage labels, including the set of policies that would be violated.
           schema:
             $ref: '#/definitions/CoreLabelsConstraints'
         '404':
+
           description: No marketing action was found for the given name.
           schema:
             $ref: '#/definitions/CoreMarketingActionNotFound'
@@ -456,8 +545,8 @@ paths:
       summary: Evaluate a core marketing action for policy violations based on datasets and/or fields.
       description: >-
         This call returns a set of constraints that would govern an attempt to perform the given marketing action on an existing data source in Platform. The source data (typically a dataset) is specified by the "entityType" and "entityId" of the elements in the request body. In the case of a dataset entity, a set of fields may also be specified in the "entityMeta" to indicate that only those fields from that dataset should be used in the evaluation. The returned constraints take the form of a set of policies that would be violated by attempting the marketing action on the dataset(s) and/or field(s).
-        
-        
+
+
         You can also evaluate a marketing action based on a defined set of usage labels instead of testing against an actual data source. See the GET method for this endpoint for more information.
       operationId: postCoreMarketingActionConstraints
       tags:
@@ -483,16 +572,23 @@ paths:
             items:
               $ref: '#/definitions/EntityLabelRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: >-
             A successful response returns the constraints on attempting to perform this marketing action on the given set of datasets and/or fields, including the set of policies that would be violated.
           schema:
             $ref: '#/definitions/CoreDatasetConstraintResponse'
         '400':
+
           description: One or more of the required fields in the request body were either missing or malformed.
           schema:
             $ref: '#/definitions/MarketingActionConstraintsError'
         '404':
+
           description: No marketing action was found for the given name.
           schema:
             $ref: '#/definitions/CoreMarketingActionNotFound'
@@ -512,6 +608,11 @@ paths:
         - $ref: '#/parameters/startQuery'
         - $ref: '#/parameters/limitQuery'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns a list of custom marketing actions.
           schema:
@@ -533,11 +634,17 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns the details of the marketing action.
           schema:
             $ref: '#/definitions/MarketingActionResponse'
         '404':
+
           description: No marketing action was found for the given name.
           schema:
             $ref: '#/definitions/CustomMarketingActionNotFound'
@@ -564,6 +671,11 @@ paths:
           schema:
             $ref: '#/definitions/MarketingActionRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: If the marketing action name indicated by the request path exists in the system, the existing entity is updated. A successful response returns details of the marketing action, indicating the entity was successfully updated.
           schema:
@@ -573,6 +685,7 @@ paths:
           schema:
             $ref: '#/definitions/MarketingActionResponse'
         '400':
+
           description: >-
              There was an error regarding the fields sent in the request payload. This occurs if the required "name" field is missing or malformed.
           schema:
@@ -593,9 +706,15 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A successful response returns an empty body, indicating the entity was deleted.
         '404':
+
           description: No marketing action was found for the given name.
           schema:
             $ref: '#/definitions/CustomMarketingActionNotFound'
@@ -604,8 +723,8 @@ paths:
       summary: Evaluate a custom marketing action for policy violations based on data usage labels.
       description: >-
         This call returns a set of constraints that would govern an attempt to perform the given marketing action on a hypothetical source of data containing specific data usage labels.
-        
-        
+
+
         You can also evaluate a marketing action based on the labels contained in an actual dataset in your data stores. See the POST method for this endpoint for more information.
       operationId: getCustomMarketingActionConstraints
       tags:
@@ -623,12 +742,18 @@ paths:
         - $ref: '#/parameters/labelsConstraintsQuery'
         - $ref: '#/parameters/includeDraftConstraintsQuery'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: >-
             A successful response returns the constraints on attempting to perform this marketing action on data bearing the given set of data usage labels, including the set of policies that would be violated.
           schema:
             $ref: '#/definitions/CustomLabelsConstraints'
         '404':
+
           description: No marketing action was found for the given name.
           schema:
             $ref: '#/definitions/CustomMarketingActionNotFound'
@@ -636,8 +761,8 @@ paths:
       summary: Evaluate a marketing action for policy violations based on datasets and/or fields.
       description: >-
         This call returns a set of constraints that would govern an attempt to perform the given marketing action on an existing data source in Platform. The source data (typically a dataset) is specified by the "entityType" and "entityId" of the elements in the request body. In the case of a dataset entity, a set of fields may also be specified in the "entityMeta" to indicate that only those fields from that dataset should be used in the evaluation. The returned constraints take the form of a set of policies that would be violated by attempting the marketing action on the dataset(s) and/or field(s).
-        
-        
+
+
         You can also evaluate a marketing action based on a defined set of usage labels instead of testing against an actual data source. See the GET method for this endpoint for more information.
       operationId: postCustomMarketingActionConstraints
       tags:
@@ -663,16 +788,23 @@ paths:
             items:
               $ref: '#/definitions/EntityLabelRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: >-
             A successful response returns the constraints on attempting to perform this marketing action on the given set of datasets and/or fields, including the set of policies that would be violated.
           schema:
             $ref: '#/definitions/CustomDatasetConstraintResponse'
         '400':
+
           description: A bad request; see response body for details
           schema:
             $ref: '#/definitions/Error'
         '404':
+
           description: No marketing action was found for the given name
           schema:
             $ref: '#/definitions/Error'
@@ -691,12 +823,12 @@ paths:
         - name: body
           description: >-
             An array of policy evaluation jobs to perform in bulk. Each job must evaluate based on one of the following:
-            
+
             * A set of labels
-            
+
             * A list of datasets and/or fields within those datasets
-            
-            
+
+
             To evaluate a marketing action based on both labels and datasets, you must include two separate jobs for that action: one that includes a **labels** array, and one that contains an **entityList** array.
           required: true
           in: body
@@ -717,6 +849,11 @@ paths:
                       fields:
                         - address
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: 'A successful response returns an array of evaluation results; one for each policy evaluation job sent in the request.'
           schema:
@@ -768,7 +905,7 @@ paths:
                       deny:
                         label: 'C1'
                         operator: 'AND'
-                        operands: 
+                        operands:
                             - label: 'C1'
                             - label: 'C3'
                       id: '76131228-7654-11e8-adc0-fa7ae01bbebc'
@@ -782,8 +919,9 @@ paths:
                       _links:
                         self:
                           href: './76131228-7654-11e8-adc0-fa7ae01bbebc'
-                  
+
         '400':
+
           description: One or more of the required fields in the request body were either missing or malformed. This error typically occurs when one of the evaluation jobs in the payload contains both a **labels** array and an **entityList** array.
           schema:
             $ref: '#/definitions/MarketingActionConstraintsError'
@@ -803,6 +941,11 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: A list of enabled core policy IDs
           schema:
@@ -824,11 +967,17 @@ paths:
           schema:
             $ref: '#/definitions/EnabledCorePoliciesRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: List of enabled core policies was successfully updated
           schema:
             $ref: '#/definitions/EnabledCorePoliciesResponse'
         '400':
+
           description: >-
             The request payload was malformed, or one of the provided policy IDs were not found.
           schema:
@@ -859,8 +1008,8 @@ parameters:
     in: header
   authorization:
     name: Authorization
-    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ". 
-    For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
+    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ".
+      For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
     required: true
     type: string
     in: header
@@ -885,7 +1034,7 @@ parameters:
   propertyQuery:
     name: property
     description: >-
-      Filters responses based on whether a specific property exists, or whose value passes a conditional expression (e.g. "?property=name==C1"). Only the "name" property is supported for core resources. For custom resources, additional supported property values include "status", "created", "createdClient", "createdUser", "updated", "updatedClient", and "updatedUser". 
+      Filters responses based on whether a specific property exists, or whose value passes a conditional expression (e.g. "?property=name==C1"). Only the "name" property is supported for core resources. For custom resources, additional supported property values include "status", "created", "createdClient", "createdUser", "updated", "updatedClient", and "updatedUser".
     required: false
     type: string
     in: query
@@ -902,7 +1051,7 @@ parameters:
   startQuery:
     name: start
     description: >-
-      Indicates the pagination value for the returned list. This value should be obtained from a previous call's '_page.next' property. Should be omitted for a first page of results. 
+      Indicates the pagination value for the returned list. This value should be obtained from a previous call's '_page.next' property. Should be omitted for a first page of results.
     type: string
     in: query
   limitQuery:
@@ -1103,7 +1252,7 @@ definitions:
     allOf:
       - $ref: '#/definitions/PolicyRequest'
     properties:
-      name: 
+      name:
         example: 'Restrict email targeting'
       status:
         example: ENABLED
@@ -1351,7 +1500,7 @@ definitions:
         items:
           type: string
       discoveredLabels:
-        description: Found in constraints POST responses only. The list of data usage labels discovered for the entity. 
+        description: Found in constraints POST responses only. The list of data usage labels discovered for the entity.
         type: array
         items:
           $ref: '#/definitions/DiscoveredLabels'
@@ -1380,7 +1529,7 @@ definitions:
         items:
           $ref: '#/definitions/CustomPolicyResponse'
       marketingActionRefs:
-        example: 
+        example:
           - https://platform.adobe.io:443/data/foundation/dulepolicy/marketingActions/custom/analyticsDB
   CoreDatasetConstraintResponse:
     allOf:
@@ -1388,7 +1537,7 @@ definitions:
       - $ref: '#/definitions/CustomDatasetConstraints'
     properties:
       marketingActionRefs:
-        example: 
+        example:
           - https://platform.adobe.io:443/data/foundation/dulepolicy/marketingActions/core/emailTargeting
   CustomDatasetConstraintResponse:
     allOf:
@@ -1856,3 +2005,31 @@ definitions:
       schemaPath:
         type: string
         example: "/properties/person/properties/name/properties/fullName"
+
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true

--- a/acpdr/swagger-specs/flow-service.yaml
+++ b/acpdr/swagger-specs/flow-service.yaml
@@ -1,5 +1,5 @@
 swagger: '2.0'
-info: 
+info:
   version: '1.0'
   title: Flow Service API
   description: >-
@@ -29,11 +29,11 @@ basePath: /data/foundation/flowservice
 tags:
   - name: Connections
     description: Connections retain information regarding how to connect to a source or target. This includes a unique connection ID, which is necessary in order to explore or navigate files and objects.
-  - name: Connection specs 
+  - name: Connection specs
     description: Connection specifications return each source’s connector properties, including authentication specifications related to creating the base, source, and target connections. Connection specifications are tenant and IMS Organization agnostic.
   - name: Flows
     description: Flows represent the data transfer between a source connection and a target connection. This also includes information regarding the ingestion schedule and the transformation specifications of the data being transferred from source to target. A flow instance is specific to a tenant and IMS Organization.
-  - name: Flow specs 
+  - name: Flow specs
     description: Flow specifications contain the information and details that define a flow. Flow specifications are tenant and IMS Organization agnostic.
   - name: Runs
     description: Runs represent an instance of flow execution. A run instance is specific to a tenant and IMS Organization.
@@ -95,11 +95,11 @@ paths:
             - **auth** - **(Required)** Contains information necessary to authenticate a base connection.
               - **specName** - **(Required)** Specifies the name of the the type of authentication to be used with the base connection.
               - **params** - **(Required)** Contains credentials and values necessary to authenticate and create a connection.
-                          
+
             - **connectionSpec** - **(Required)** Contains information regarding the source's connection specification ID.
               - **id** - **(Required)** The specific connection specification ID associated with source.
               - **version** - Specifies the version of the connection specification ID. Omitting this value will default to the most recent version
-            
+
           required: true
           schema:
             $ref: '#/definitions/CreateConnectionRequest'
@@ -248,7 +248,7 @@ paths:
             - **path** - (Optional) The path of the parameter to be updated.
 
             - **value** - **(Required)** The new value you want to update your parameter with.
-            
+
           required: true
           schema:
             $ref: '#/definitions/PatchInstruction'
@@ -267,7 +267,7 @@ paths:
       tags:
         - Connections
       summary: Delete an existing connection by its ID.
-      operationId: deleteByConnectionId 
+      operationId: deleteByConnectionId
       consumes:
         - application/json
       produces:
@@ -362,7 +362,7 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'        
+        - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/limit'
         - $ref: '#/parameters/orderby'
@@ -399,26 +399,26 @@ paths:
             - **name** - **(Required)** The name of the flow to be created.
 
             - **description** - (Optional) The description provides information and details regarding the flow to be created.
-            
+
             - **flowSpec** - **(Required)** The flowSpec contains information regarding flow specifications, including its flow specification ID and version.
               - **id** - The specific flow specification ID used to create a flow.
               - **version** - Specifies the version of the flow specification ID. Omitting this value will default to the most recent version.
-            
+
             - **sourceConnectionIds** - **(Required)** The ID of the source connection generated using the source's base connection ID and connection specification IDs.
-            
+
             - **targetConnectionIds** - **(Required)** The ID of the target connection. This ID is needed to manage a destination connection to Platform.
-            
+
             - **transformations** - **(Required)** Contains various transformations that will be done as part of the flow.
               - **name** - **(Required)** The name assigned to the transformation.
               - **params** - **(Required)** Contains information about the transformation that will be completed. Sources categorized as either CRM or relational database require the use of the "deltaColumn" param. Other categories do not.
-              
+
             - **scheduleParams** - **(Required)** Contains information regarding the ingestion scheduling of the flow.
               - **startTime** - Designates the start time for flow in epoch time in seconds.
               - **frequency** - Designates the scheduled frequency of ingestion for a flow. Valid values include once, minute, hour, day, week.
               - **interval** - Designates the period between two consecutive flow runs. Its assigned value should be a non zero integer. Interval is not required when frequency is set as once, and should be set as equal or greater than 15 if frequency is set on a per minute basis. There are no constraints on interval for other frequency settings.
               - **backfill** - A boolean value that determines what data is initially ingested. If backfill is enabled, all current files in the specified path will be ingested during the first scheduled ingestion. If backfill is disabled, only the files that are loaded in between the first run of ingestion and the Start time will be ingested. Files loaded prior to Start time will not be ingested.
-            
-              
+
+
           required: true
           schema:
             $ref: '#/definitions/CreateFlowRequest'
@@ -498,7 +498,7 @@ paths:
             - **path** - (Optional) The path of the parameter to be updated.
 
             - **value** - **(Required)** The new value you want to update your parameter with.
-            
+
           required: true
           schema:
             type: array
@@ -520,7 +520,7 @@ paths:
       tags:
         - Flows
       summary: Delete an existing flow by its ID.
-      operationId: deleteByFlowId 
+      operationId: deleteByFlowId
       consumes:
         - application/json
       produces:
@@ -649,7 +649,7 @@ paths:
           name: body
           description: >-
             - **status** - **(Required)** The state of the run.
-            
+
             - **flowId** - **(Required)** The flowId associated with the run.
           required: true
           schema:
@@ -719,22 +719,22 @@ paths:
           name: body
           description: >-
             - **name** - **(Required)** The name of the source connection.
-            
+
             - **baseConnectionId** - **(Required)** The ID of the connection from which the source connection is derived.
 
             - **description** - (Optional) Provides information and details regarding the source connection to be created.
-            
+
             - **data** - **(Required)** Contains information regarding the source connection's data format and the schema to map to.
               - **format** - **(Required)** The format of the data file to be ingested. Possible enum values for file-based connectors include `delimted`, `json`, and `parquet`. For table-based connectors, use the value `tabular`.
               - **version** - **(Required)** Specifies the version of the format of the data being ingested. Omitting this value will default to the most recent version
-              
+
             - **params** - **(Required)** Defines details of source of data in this source connection from where data should be copied.
               - **path** - **(Required)** Designates the path file.
-            
+
             - **connectionSpec** - **(Required)** Contains information regarding the source's connection specification ID.
               - **id** - **(Required)** The specific connection specification ID associated with source.
               - **version** - Specifies the version of the connection specification ID. Omitting this value will default to the most recent version.
-            
+
           required: true
           schema:
             $ref: '#/definitions/CreateSourceConnectionRequest'
@@ -785,7 +785,7 @@ paths:
           description: OAuth token is missing.
         '503':
           description: The service is unavailable.
-          
+
     patch:
       tags:
         - Source connections
@@ -815,7 +815,7 @@ paths:
             - **path** - (Optional) The path of the parameter to be updated.
 
             - **value** - **(Required)** The new value you want to update your parameter with.
-            
+
           required: true
           schema:
             type: array
@@ -832,7 +832,7 @@ paths:
           description: The service is unavailable.
 
     delete:
-      tags: 
+      tags:
         - Source connections
       summary: Delete an existing source connection by its ID.
       operationId: deleteSourceConnectionById
@@ -879,16 +879,16 @@ paths:
           name: body
           description: >-
             - **name** - **(Required)** The name of the source connection.
-            
+
             - **description** - (Optional) Provides information and details regarding the source connection to be created.
-            
+
             - **data** - **(Required)** Contains information regarding the source connection's data format and the schema to map to.
               - **schema** - **(Required)** Contains information regarding the target schema, including its unique reference identifier and version.
                 - **ID** - **(Required)** The unique ID reference for the target XDM schema.
                 - **version** - **(Required)** Specifies the version of the data.format. Omitting this value will default to the most recent version
-            - **params** - **(Required)** Defines details of data in this target connection where data should be copied to.  
+            - **params** - **(Required)** Defines details of data in this target connection where data should be copied to.
             - **dataSetId** - **(Required)** The target dataset ID used to create a target connection.
-            
+
             - **connectionSpec** - **(Required)** Contains information regarding the source's connection specification ID.
               - **id** - The specific connection specification ID associated with source.
               - **version** - Specifies the version of the connection specification ID. Omitting this value will default to the most recent version
@@ -940,7 +940,7 @@ paths:
           description: OAuth token is missing.
         '503':
           description: The service is unavailable.
-          
+
     patch:
       tags:
         - Target connections
@@ -970,7 +970,7 @@ paths:
             - **path** - (Optional) The path of the parameter to be updated.
 
             - **value** - **(Required)** The new value you want to update your parameter with.
-            
+
           required: true
           schema:
             type: array
@@ -1029,19 +1029,7 @@ definitions:
         $ref: '#/definitions/AuthCreateBaseDTO'
   AuthCreateBaseDTO:
     type: object
-    properties:
-      url:
-        type: string
-        example: "{URL}"
-      servicePrincipalId:
-        type: string
-        example: "{SERVICE_PRINCIPAL_ID}"
-      servicePrincipalKey:
-        type: string
-        example: "{SERVICE_PRINCIPAL_KEY}"
-      tenant:
-        type: string
-        example: "{TENANT}"
+    additionalProperties: true
   ConnectionItemDTO:
     type: object
     properties:
@@ -2129,7 +2117,7 @@ parameters:
     description: "The unique token associated with the user account."
     required: false
     type: string
-  limit:  
+  limit:
     name: limit
     in: query
     description: "Limit response to a specific number of objects. Must be a positive number. For example, `limit=10`"

--- a/acpdr/swagger-specs/flow-service.yaml
+++ b/acpdr/swagger-specs/flow-service.yaml
@@ -63,15 +63,25 @@ paths:
         - $ref: '#/parameters/continuationToken'
         - $ref: '#/parameters/count'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns a list of connections in JSON format.
           schema:
             $ref: '#/definitions/ConnectionListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     post:
       tags:
@@ -106,6 +116,10 @@ paths:
           schema:
             $ref: '#/definitions/CreateConnectionRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Returns new base connection ID and etag.
           examples:
@@ -119,8 +133,12 @@ paths:
           schema:
             $ref: '#/definitions/CreateConnectionResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/connections/{CONNECTION_ID}':
     get:
@@ -144,15 +162,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns details for specified base connection in JSON format
           schema:
             $ref: '#/definitions/ConnectionListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/connections/{CONNECTION_ID}/test':
     get:
@@ -176,15 +204,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns connection status of specified connection ID.
           schema:
             $ref: '#/definitions/TestConnectionResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/connections/{CONNECTION_ID}/explore':
     get:
@@ -208,6 +246,10 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns file structure of specified connection ID, including details regarding type, name, path and if file can be previewed or fetched.
           examples:
@@ -221,10 +263,16 @@ paths:
           schema:
             $ref: '#/definitions/ExploreConnectionResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/connections/{CONNECTION_ID}/':
     patch:
@@ -261,6 +309,10 @@ paths:
           schema:
             $ref: '#/definitions/PatchInstruction'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Connection successfully updated.
           examples:
@@ -268,8 +320,12 @@ paths:
               id: "139f6a5f-a78b-4744-9f6a-5fa78bd74431"
               etag: "\"3600e378-0000-0200-0000-5f40212f0000\""
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     delete:
       tags:
@@ -292,6 +348,10 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: Connection successfully deleted.
           examples:
@@ -299,10 +359,16 @@ paths:
               id: "f9377f50-607a-4818-b77f-50607a181860"
               etag: "\"03004116-0000-0200-0000-5edfbf2d0000\""
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   /connectionSpecs:
     get:
@@ -321,15 +387,25 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/property'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns a list of connection specifications in JSON format.
           schema:
             $ref: '#/definitions/ConnectionSpecResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/connectionSpecs/{CONNECTION_SPEC_ID}':
     get:
@@ -352,15 +428,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns details of specified connection specification in JSON format.
           schema:
             $ref: '#/definitions/ConnectionSpecResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Problem accessing /connectionSpecs/{CONNECTION_ID}
   /flows:
     get:
@@ -383,17 +469,29 @@ paths:
         - $ref: '#/parameters/continuationToken'
         - $ref: '#/parameters/count'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns a list of flows in JSON format.
           schema:
             $ref: '#/definitions/FlowListResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Header=[x-sandbox-id] not allowed with user token.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     post:
       tags:
@@ -439,6 +537,10 @@ paths:
           schema:
             $ref: '#/definitions/CreateFlowRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Returns new flow ID and etag.
           examples:
@@ -451,8 +553,12 @@ paths:
           schema:
             $ref: '#/definitions/CreateFlowResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/flows/{FLOW_ID}':
     get:
@@ -476,15 +582,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns details of specified flow in JSON format.
           schema:
             $ref: '#/definitions/FlowListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
 
     patch:
@@ -523,15 +639,25 @@ paths:
             items:
               $ref: '#/definitions/PatchInstruction'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The flow was successfully updated.
           schema:
             $ref: '#/definitions/CreateFlowResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
 
     delete:
@@ -555,6 +681,10 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '202':
           description: Flow delete request accepted.
           schema:
@@ -562,10 +692,16 @@ paths:
         '204':
           description: Flow successfully deleted.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   /flowSpecs:
     get:
@@ -584,15 +720,25 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/property'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns a list of flow specifications in JSON format.
           schema:
             $ref: '#/definitions/FlowSpecResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/flowSpecs/{FLOW_SPEC_ID}':
     get:
@@ -616,15 +762,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns details of specified flow specification in JSON format.
           schema:
             $ref: '#/definitions/FlowSpecResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   /runs:
     get:
@@ -647,15 +803,25 @@ paths:
         - $ref: '#/parameters/continuationToken'
         - $ref: '#/parameters/count'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns a list of runs in JSON format.
           schema:
             $ref: '#/definitions/FlowRunsListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     post:
       tags:
@@ -681,6 +847,10 @@ paths:
           schema:
             $ref: '#/definitions/CreateFlowRunRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Returns new run ID and etag.
           examples:
@@ -693,8 +863,12 @@ paths:
           schema:
             $ref: '#/definitions/CreateFlowRunResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/runs/{RUN_ID}':
     get:
@@ -718,15 +892,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns details of specified run in JSON format.
           schema:
             $ref: '#/definitions/FlowRunsListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   /sourceConnections:
     post:
@@ -767,6 +951,10 @@ paths:
           schema:
             $ref: '#/definitions/CreateSourceConnectionRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Returns new source connection ID and etag.
           examples:
@@ -780,8 +968,12 @@ paths:
           schema:
             $ref: '#/definitions/CreateSourceConnectionResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/sourceConnections/{SOURCE_CONNECTION_ID}':
     get:
@@ -805,15 +997,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns details of specified source connection in JSON format.
           schema:
             $ref: '#/definitions/SourceConnectionsListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
 
     patch:
@@ -852,13 +1054,21 @@ paths:
             items:
               $ref: '#/definitions/PatchInstruction'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns updated source connection in JSON format.
           schema:
             $ref: '#/definitions/SourceConnectionsListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
 
     delete:
@@ -882,15 +1092,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: The source connection was successfully deleted.
           schema:
             $ref: '#/definitions/SourceConnectionsListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   /targetConnections:
     post:
@@ -928,6 +1148,10 @@ paths:
           schema:
             $ref: '#/definitions/CreateTargetConnectionRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Returns new target connection ID and etag.
           examples:
@@ -940,8 +1164,12 @@ paths:
           schema:
             $ref: '#/definitions/CreateTargetConnectionResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/targetConnections/{TARGET_CONNECTION_ID}':
     get:
@@ -964,15 +1192,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns details of specified target connection in JSON format.
           schema:
             $ref: '#/definitions/TargetConnectionsListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
 
     patch:
@@ -1011,13 +1249,21 @@ paths:
             items:
               $ref: '#/definitions/PatchInstruction'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns details of specified target connection in JSON format.
           schema:
             $ref: '#/definitions/TargetConnectionsListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
 
     delete:
@@ -1041,15 +1287,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: The target connection was successfully deleted.
           schema:
             $ref: '#/definitions/TargetConnectionsListResponse'
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: OAuth token is missing.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
 definitions:
   AuthInfoDTO:
@@ -2104,6 +2360,33 @@ definitions:
             type: string
             example: "A new description to provide further context on a specified connection or flow."
             description: The new description value you want to add.
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
 parameters:
   authorization:
     name: Authorization

--- a/acpdr/swagger-specs/flow-service.yaml
+++ b/acpdr/swagger-specs/flow-service.yaml
@@ -69,6 +69,8 @@ paths:
             $ref: '#/definitions/ConnectionListResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
     post:
@@ -148,6 +150,8 @@ paths:
             $ref: '#/definitions/ConnectionListResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   '/connections/{CONNECTION_ID}/test':
@@ -178,6 +182,8 @@ paths:
             $ref: '#/definitions/TestConnectionResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   '/connections/{CONNECTION_ID}/explore':
@@ -216,6 +222,8 @@ paths:
             $ref: '#/definitions/ExploreConnectionResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   '/connections/{CONNECTION_ID}/':
@@ -292,6 +300,8 @@ paths:
               etag: "\"03004116-0000-0200-0000-5edfbf2d0000\""
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   /connectionSpecs:
@@ -317,6 +327,8 @@ paths:
             $ref: '#/definitions/ConnectionSpecResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   '/connectionSpecs/{CONNECTION_SPEC_ID}':
@@ -346,6 +358,8 @@ paths:
             $ref: '#/definitions/ConnectionSpecResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '500':
           description: Problem accessing /connectionSpecs/{CONNECTION_ID}
   /flows:
@@ -377,6 +391,8 @@ paths:
           description: Header=[x-sandbox-id] not allowed with user token.
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
     post:
@@ -466,6 +482,8 @@ paths:
             $ref: '#/definitions/FlowListResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
 
@@ -545,6 +563,8 @@ paths:
           description: Flow successfully deleted.
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   /flowSpecs:
@@ -570,6 +590,8 @@ paths:
             $ref: '#/definitions/FlowSpecResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   '/flowSpecs/{FLOW_SPEC_ID}':
@@ -600,6 +622,8 @@ paths:
             $ref: '#/definitions/FlowSpecResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   /runs:
@@ -629,6 +653,8 @@ paths:
             $ref: '#/definitions/FlowRunsListResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
     post:
@@ -698,6 +724,8 @@ paths:
             $ref: '#/definitions/FlowRunsListResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   /sourceConnections:
@@ -783,6 +811,8 @@ paths:
             $ref: '#/definitions/SourceConnectionsListResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
 
@@ -858,6 +888,8 @@ paths:
             $ref: '#/definitions/SourceConnectionsListResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
   /targetConnections:
@@ -938,6 +970,8 @@ paths:
             $ref: '#/definitions/TargetConnectionsListResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
 
@@ -1013,6 +1047,8 @@ paths:
             $ref: '#/definitions/TargetConnectionsListResponse'
         '401':
           description: OAuth token is missing.
+        '404':
+          description: Not Found
         '503':
           description: The service is unavailable.
 definitions:

--- a/acpdr/swagger-specs/id-service-api.yaml
+++ b/acpdr/swagger-specs/id-service-api.yaml
@@ -4,7 +4,7 @@ info:
   version: '1.0'
   description: >-
     Delivering relevant digital experiences requires having a complete understanding of your customer. This is made more difficult when your customer data is fragmented across disparate systems, causing each individual customer to appear to have multiple "identities". Adobe Experience Platform Identity Service provides a RESTful API to help you to gain a better view of your customers and their behavior. By bridging identities across devices and systems, you are better able to deliver impactful, personal digital experiences in real-time.
-    
+
 
     Related documentation:
       * [Identity Service documentation](http://www.adobe.com/go/identity-overview-en)
@@ -85,6 +85,9 @@ paths:
           type: string
           default: application/vnd.adobe.identity+json;version=1.2
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           description: OK
           schema:
@@ -103,6 +106,7 @@ paths:
               type: string
               default: no-cache
         '400':
+
           description: Bad Request from the client
           schema:
             type: object
@@ -127,6 +131,7 @@ paths:
               default: no-cache
 
         '401':
+
           description: IMS token is missing required scope.
           schema:
             type: object
@@ -164,6 +169,7 @@ paths:
                 type: string
                 example:  Request rate is large. Please try again later.
         '500':
+
           description: Unexpected Internal application error
           schema:
             type: object
@@ -200,7 +206,7 @@ paths:
           description: namespace id
           required: false
           type: integer
-          default: '411'
+          default: 411
         - name: namespace
           in: query
           description: namespace code
@@ -232,6 +238,9 @@ paths:
           type: string
           default: application/vnd.adobe.identity+json;version=1.2
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           examples:
             value:
@@ -255,6 +264,7 @@ paths:
               type: string
               default: no-cache
         '400':
+
           description: Bad Request from the client
           schema:
             type: object
@@ -278,6 +288,7 @@ paths:
               type: string
               default: no-cache
         '401':
+
           description: IMS token is missing required scope.
           schema:
             type: object
@@ -315,6 +326,7 @@ paths:
                 type: string
                 example:  Request rate is large. Please try again later.
         '500':
+
           description: Unexpected Internal application error
           schema:
             type: object
@@ -365,6 +377,9 @@ paths:
             items:
               $ref: '#/definitions/ListOfIdentity'
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           examples:
             value:
@@ -390,6 +405,7 @@ paths:
               type: string
               default: no-cache
         '400':
+
           description: Bad Request from the client
           schema:
             type: object
@@ -413,6 +429,7 @@ paths:
               type: string
               default: no-cache
         '401':
+
           description: IMS token is missing required scope.
           schema:
             type: object
@@ -450,6 +467,7 @@ paths:
                 type: string
                 example:  Request rate is large. Please try again later.
         '500':
+
           description: Unexpected Internal application error
           schema:
             type: object
@@ -498,7 +516,7 @@ paths:
           description: namespace id
           required: false
           type: integer
-          default: '411'
+          default: 411
         - name: namespace
           in: query
           description: namespace code
@@ -518,6 +536,9 @@ paths:
           type: string
           default: Private Graph
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           examples:
             value:
@@ -545,6 +566,7 @@ paths:
               type: string
               default: no-cache
         '400':
+
           description: Bad Request from the client
           schema:
             type: object
@@ -568,6 +590,7 @@ paths:
               type: string
               default: no-cache
         '401':
+
           description: IMS token is missing required scope.
           schema:
             type: object
@@ -605,6 +628,7 @@ paths:
                 type: string
                 example:  Request rate is large. Please try again later.
         '500':
+
           description: Unexpected Internal application error
           schema:
             type: object
@@ -653,6 +677,9 @@ paths:
           schema:
             $ref: '#/definitions/ListOfIdentity'
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           examples:
             value:
@@ -684,6 +711,7 @@ paths:
               type: string
               default: no-cache
         '400':
+
           description: Bad Request from the client
           schema:
             type: object
@@ -707,6 +735,7 @@ paths:
               type: string
               default: no-cache
         '401':
+
           description: IMS token is missing required scope.
           schema:
             type: object
@@ -744,6 +773,7 @@ paths:
                 type: string
                 example:  Request rate is large. Please try again later.
         '500':
+
           description: Unexpected Internal application error
           schema:
             type: object
@@ -757,7 +787,7 @@ paths:
               description:
                 type: string
                 example:  An unexpected internal error occurred in the server. This might indicate a problem with the request, or might indicate a problem in the server side code.
-  /identity/mapping:  
+  /identity/mapping:
     get:
       tags:
         - Mappings
@@ -812,6 +842,9 @@ paths:
           type: integer
           default: 411
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           examples:
             value:
@@ -838,6 +871,7 @@ paths:
               type: string
               default: no-cache
         '400':
+
           description: Bad Request from the client
           schema:
             type: object
@@ -861,6 +895,7 @@ paths:
               type: string
               default: no-cache
         '401':
+
           description: IMS token is missing required scope.
           schema:
             type: object
@@ -898,6 +933,7 @@ paths:
                 type: string
                 example:  Request rate is large. Please try again later.
         '500':
+
           description: Unexpected Internal application error
           schema:
             type: object
@@ -945,6 +981,9 @@ paths:
           schema:
             $ref: '#/definitions/ListOfMappings'
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           examples:
             value:
@@ -978,6 +1017,7 @@ paths:
               type: string
               default: no-cache
         '400':
+
           description: Bad Request from the client
           schema:
             type: object
@@ -1001,6 +1041,7 @@ paths:
               type: string
               default: no-cache
         '401':
+
           description: IMS token is missing required scope.
           schema:
             type: object
@@ -1038,6 +1079,7 @@ paths:
                 type: string
                 example:  Request rate is large. Please try again later.
         '500':
+
           description: Unexpected Internal application error
           schema:
             type: object
@@ -1052,6 +1094,7 @@ paths:
                 type: string
                 example:  An unexpected internal error occurred in the server. This might indicate a problem with the request, or might indicate a problem in the server side code.
         '503':
+
           description: The service is unavailable
           schema:
             $ref: '#/definitions/ServiceErrorStatus'
@@ -1068,11 +1111,15 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           description: Returns a list of all ID namespaces as an array with individual objects containing the details for each namespace.
           schema:
             $ref: '#/definitions/listNamespaces'
         '401':
+
           description: Authentication failure for invalid IMS token.
           schema:
             type: object
@@ -1099,6 +1146,7 @@ paths:
                     type: string
                     example: Authorization failed - Missing product context acp for given IMS token.
         '500':
+
           description: Internal server error
           schema:
             type: object
@@ -1140,11 +1188,15 @@ paths:
       summary: Create a new identity namespace.
       operationId: CreateNameSpace
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           description: Identity namespace created successfully. Returns details of newly created identity namespace.
           schema:
             $ref: '#/definitions/Namespace'
         '400':
+
           description: Creation of namespace failed because of data-issue.
           schema:
             type: object
@@ -1171,6 +1223,7 @@ paths:
                     type: string
                     example: INVALID_REQUEST_PARAMS
         '401':
+
           description: Authentication failure for invalid IMS token.
           schema:
             type: object
@@ -1223,6 +1276,7 @@ paths:
                     type: string
                     example: INTEGRATION_CODE_EXISTS
         '500':
+
           description: Internal server error
           schema:
             type: object
@@ -1262,11 +1316,15 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           description: OK
           schema:
             $ref: '#/definitions/Namespace'
         '401':
+
           description: Authentication failure for invalid IMS token.
           schema:
             type: object
@@ -1293,6 +1351,7 @@ paths:
                     type: string
                     example: Authorization failed - Missing product context acp for given IMS token.
         '404':
+
           description: Namespace does not exist or it is not available for the given imsorg
           schema:
             type: object
@@ -1322,6 +1381,7 @@ paths:
                     type: string
                     example: NAMESPACE_NOT_FOUND
         '500':
+
           description: Internal server error
           schema:
             type: object
@@ -1369,6 +1429,9 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           description: Returns the details of the updated identity namespace. ID should match the ID sent in the request path.
           schema:
@@ -1376,6 +1439,7 @@ paths:
             items:
               $ref: '#/definitions/updateNamespace'
         '400':
+
           description: Invalid request to update the namespace.
           schema:
             type: object
@@ -1405,6 +1469,7 @@ paths:
                     type: string
                     example: INVALID_REQUEST_PARAMS
         '401':
+
           description: Authentication failure for invalid IMS token.
           schema:
             type: object
@@ -1431,6 +1496,7 @@ paths:
                     type: string
                     example: Authorization failed - Missing product context acp for given IMS token.
         '404':
+
           description: Namespace does not exist or it is not available for the given imsorg
           schema:
             type: object
@@ -1460,6 +1526,7 @@ paths:
                     type: string
                     example: NAMESPACE_NOT_FOUND
         '500':
+
           description: Internal server error
           schema:
             type: object
@@ -1499,11 +1566,15 @@ paths:
       - $ref: '#/parameters/x-api-key'
       - $ref: '#/parameters/x-gw-ims-org-id'
       responses:
+        default:
+          description: Unexpected error
+
         '200':
-          description: Returns a list of all namespaces shared by the IMS Org, or all owned namespaces if the IMS Org sent in the path matches the IMS Org sent in the header. 
+          description: Returns a list of all namespaces shared by the IMS Org, or all owned namespaces if the IMS Org sent in the path matches the IMS Org sent in the header.
           schema:
             $ref: '#/definitions/listNamespaces'
         '400':
+
           description: Invalid IMS Org in request
           schema:
             type: object
@@ -1533,6 +1604,7 @@ paths:
                     type: string
                     example: 'INVALID_REQUEST_PARAMS'
         '401':
+
           description: Authentication failure for invalid IMS token.
           schema:
             type: object
@@ -1559,6 +1631,7 @@ paths:
                     type: string
                     example: Authorization failed - Missing product context acp for given IMS token.
         '500':
+
           description: Internal server error
           schema:
             type: object
@@ -1599,6 +1672,9 @@ paths:
       - $ref: '#/parameters/x-api-key'
       - $ref: '#/parameters/x-gw-ims-org-id'
       responses:
+        default:
+          description: Unexpected error
+
         '200':
           description: Returns the details of a specific identity namespace that is owned by the IMS Org sent in the request path, only if that namespace ID is accessible to the IMS Org sent in the request header.
           schema:
@@ -1606,6 +1682,7 @@ paths:
             items:
               $ref: '#/definitions/Namespace'
         '401':
+
           description: Authentication failure for invalid IMS token.
           schema:
             type: object
@@ -1632,6 +1709,7 @@ paths:
                     type: string
                     example: Authorization failed - Missing product context acp for given IMS token.
         '404':
+
           description: Namespace does not exist or it is not available for the given imsorg
           schema:
             type: object
@@ -1661,6 +1739,7 @@ paths:
                     type: string
                     example: NAMESPACE_NOT_FOUND
         '500':
+
           description: Internal server error
           schema:
             type: object
@@ -1686,11 +1765,38 @@ paths:
                   message:
                     type: string
                     example: Internal server error occurred. Please try at a later time.
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
 parameters:
   authorization:
     name: Authorization
-    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ". 
-    For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
+    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ".
+      For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
     required: true
     type: string
     in: header
@@ -1728,15 +1834,15 @@ parameters:
     in: body
     required: true
     name: body
-    description: >- 
+    description: >-
       JSON object containing the details of the namespace to be created.
-      
-      * **name:** **(Required)** A friendly name (or "Display Name") for the namespace.  
-      
+
+      * **name:** **(Required)** A friendly name (or "Display Name") for the namespace.
+
       * **code:** **(Required)** Known as the "Identity symbol" in the user interface, the "code" is a single word descriptor for the namespace being created. Must be unique. May contain only letters and numbers.
-      
+
       * **idType:** **(Required)** The "type" of namespace being created. Must be one of the following values: Cookie, Cross-device, Device, Email, Mobile, Non-people, or Phone.
-      
+
       * **description:** *(Optional)* A description for the namespace. This is especially useful when multiple namespaces have been defined for your organization.
     schema:
         $ref: '#/definitions/namespaceCreate'

--- a/acpdr/swagger-specs/ingest-api.yaml
+++ b/acpdr/swagger-specs/ingest-api.yaml
@@ -89,23 +89,37 @@ paths:
             - true
             - false
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: "The data was successfully ingested."
           schema:
             $ref: "#/definitions/StreamingIngestionResponse"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was a problem with the request. See the response body for a more specific error message.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is unauthorized. The user needs to provide a valid bearer token.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '413':
           description: The payload is larger than 1 MB.
         '429':
           description: Too many requests. The service is experiencing high loads.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has ocurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is currently unavailable. Clients should retry at least three times using an exponential back-off strategy.
           headers:
             Retry-After:
@@ -144,27 +158,43 @@ paths:
             - true
             - false
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '207':
           description: "A multi-status code. The recipient needs to consult the contents of the multi-status response body for further information about the success or failure of the method execution."
           schema:
             $ref: "#/definitions/BatchResponseDTO"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: >-
             There was a problem with the request. See the response body for a
             more specific error message.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is unauthorized. The user needs to provide a valid bearer token.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Can't find connection or inlet.
         '413':
           description: The payload is larger than 1 MB.
         '429':
           description: Too many requests. The service is experiencing high loads.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error has occurred.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is currently unavailable. Clients should retry at least three times using an exponential back-off strategy.
           headers:
             Retry-After:
@@ -193,19 +223,31 @@ paths:
           schema:
             $ref: "#/definitions/IngestBatch"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: "The batch was successfully created."
           schema:
             $ref: "#/definitions/Batch"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "A bad request. The request is malformed."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized. The user needs to provide a valid bearer token."
         414:
           description: "The URL length exceeds the allowed 2000 characters."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has occurred."
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The service is currently unavailable."
   /batches/{batchId}/datasets/{datasetId}/files/{filePath}:
     put:
@@ -248,21 +290,33 @@ paths:
           type: "string"
           description: "The location where the file will be uploaded to, on the Adobe side. **Note:** The directory structure denoted in this path is preserved and can be used to denote partitions that the file data belongs to."
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The file was successfully updated."
         201:
           description: "The file was successfully created."
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The request is malformed."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized. The IMS token provided is invalid."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The batch or dataset resource is not found."
         414:
           description: "The URL length exceeds the allowed 2000 characters."
         415:
           description: "The uploaded file media type isn't supported."
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The service is unavailable."
     patch:
       tags:
@@ -309,6 +363,10 @@ paths:
           required: true
           description: The content bytes for the file or file part being uploaded.
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The file was successfully uploaded."
           headers:
@@ -318,18 +376,28 @@ paths:
           schema:
             $ref: "#/definitions/File"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The request is malformed."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized. The IMS token provided is invalid."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The batch, dataset, or file resource is not found."
         414:
           description: "The URL length exceeds the allowed 2000 characters."
         415:
           description: "The uploaded file media type isn't supported."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has occurred."
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The service is unavailable."
     post:
       tags:
@@ -367,21 +435,35 @@ paths:
           description: 'The action to perform on the file. Currently, the supported values are "INITIALIZE" and "COMPLETE". To begin initializing the file for upload, use the value "INITIALIZE". To mark the file as finished, use the value "COMPLETE".'
           enum: ["INITIALIZE", "COMPLETE"]
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The file is now finished uploading."
           schema:
             $ref: "#/definitions/File"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The request is malformed."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized. The IMS token provided is invalid."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The batch, dataset, or file resource is not found."
         414:
           description: "The URL length exceeds the allowed 2000 characters."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has occurred."
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The service is unavailable."
     head:
       tags:
@@ -410,6 +492,10 @@ paths:
           type: "string"
           description: "The location of the file you want to retrieve status information about, on the Adobe side. **Note:** The directory structure denoted in this path is preserved and can be used to denote partitions that the file data belongs to."
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The status information was successfully returned."
           headers:
@@ -417,18 +503,28 @@ paths:
               type: "string"
               description: "bytes 0-512000000"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The request is malformed."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized. The IMS token provided is invalid."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The batch, dataset, or file resource is not found."
         414:
           description: "URL length exceeds the allowed 2000 characters."
         415:
           description: "The uploaded file media type isn't supported."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has occurred."
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The service is unavailable."
   /batches/{batchId}/datasets/{datasetId}/preview:
     get:
@@ -497,23 +593,37 @@ paths:
           format: "int32"
           description: "The number of rows to parse."
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The preview for the batch was successfully generated."
           schema:
             $ref: "#/definitions/PreviewResponse"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The request is malformed."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized. The IMS token provided is invalid."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The batch or dataset resource is not found."
         414:
           description: "The URL length exceeds the allowed 2000 characters."
         415:
           description: "The uploaded file media type isn't supported."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has occurred."
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The service is unavailable."
   /batches/{batchId}:
     post:
@@ -541,22 +651,37 @@ paths:
           description: "The action to take on the batch. To signal that it's completed, use 'COMPLETE'."
           enum: ["COMPLETE", "ABORT","FAIL", "REVERT"]
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "The batch has been successfully promoted."
           schema:
             $ref: "#/definitions/Batch"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The request is malformed."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized. The IMS token provided is invalid."
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The batch is not found."
         414:
           description: "The URL length exceeds the allowed 2000 characters."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has occurred."
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "The service is unavailable."
+
 parameters:
   authorization:
     name: Authorization
@@ -1048,3 +1173,31 @@ definitions:
       },
     }
   }
+
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true

--- a/acpdr/swagger-specs/ingest-api.yaml
+++ b/acpdr/swagger-specs/ingest-api.yaml
@@ -937,9 +937,12 @@ definitions:
       xactionId: "1532625558467:0001:13"
       receivedTimeMs: "1551307525735"
   BatchMessage:
-    type: array
-    items:
-      $ref: "#/definitions/streamingMessage"
+    type: object
+    properties:
+      messages:
+        type: array
+        items:
+          $ref: "#/definitions/streamingMessage"
     description: "The batch message to be published to Platform."
     example:
       {

--- a/acpdr/swagger-specs/ingest-api.yaml
+++ b/acpdr/swagger-specs/ingest-api.yaml
@@ -19,11 +19,11 @@ info:
         - Data inlet management: https://<span>platform.adobe.io/data/core/edge
         - Data collection: https://<span>dcs.adobedc.net/
       - Example of a complete path for batch ingestion: https://<span>platform.adobe.io/data/foundation/import/batches
-     
+
     - Required headers:
       - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
       - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
-      - Requests with a payload in the request body (such as POST, PUT, and PATCH calls) may require the header `Content-Type`. Accepted values specific to each call are provided in the call parameters.  
+      - Requests with a payload in the request body (such as POST, PUT, and PATCH calls) may require the header `Content-Type`. Accepted values specific to each call are provided in the call parameters.
 
   version: "1.0"
 basePath: /data/foundation/import
@@ -787,7 +787,7 @@ definitions:
         properties: {}
       tags:
         type: object
-        description: Tags are values associated with a particular object. These are generally used by external systems for marking an object in a way that it understands. 
+        description: Tags are values associated with a particular object. These are generally used by external systems for marking an object in a way that it understands.
         properties: {}
       inputFormat:
         type: object
@@ -883,7 +883,7 @@ definitions:
         properties:
           format:
             type: "string"
-            enum: 
+            enum:
             - JSON
             - Parquet
             - CSV
@@ -955,7 +955,7 @@ definitions:
               timestamp: "2019-02-23T22:07:01Z",
               environment: {
                 browserDetails: {
-                  userAgent: "Mozilla\/5.0 (Windows NT 5.1) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.57 Safari\/537.36 OPR\/16.0.1196.62",
+                  userAgent: Mozilla\/5.0 (Windows NT 5.1) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.57 Safari\/537.36 OPR\/16.0.1196.62,
                   acceptLanguage: "en-US",
                   cookiesEnabled: "true",
                   javaScriptVersion: "1.6",

--- a/acpdr/swagger-specs/ingest-api.yaml
+++ b/acpdr/swagger-specs/ingest-api.yaml
@@ -156,6 +156,8 @@ paths:
           description: Access is unauthorized. The user needs to provide a valid bearer token.
         '403':
           description: Access is forbidden.
+        '404':
+          description: Can't find connection or inlet.
         '413':
           description: The payload is larger than 1 MB.
         '429':

--- a/acpdr/swagger-specs/ingest-api.yaml
+++ b/acpdr/swagger-specs/ingest-api.yaml
@@ -868,17 +868,16 @@ definitions:
           type: integer
   IngestBatch:
     type: "object"
+    required: ["datasetId", "inputFormat"]
     properties:
       datasetId:
         type: "string"
         description: "Required. The ID of the dataset that you are creating a batch for."
-        required: true
       externalId:
         description: A client supplied batch identifier, that is expected to be unique within an IMS Organization. Defaults to batch ID if not specified.
         type: "string"
       inputFormat:
         description: Required. The format of the ingested batch. It can be any of the following values.
-        required: true
         type: "object"
         properties:
           format:
@@ -901,8 +900,6 @@ definitions:
             type: "array"
             items:
               type: "string"
-        items:
-          type: "string"
       tags:
         type: object
         description:  >-

--- a/acpdr/swagger-specs/ingest-api.yaml
+++ b/acpdr/swagger-specs/ingest-api.yaml
@@ -597,33 +597,36 @@ parameters:
     in: header
 definitions:
   streamingMessage:
-    type: "object"
-    required:
-      - SCHEMA_ID
-      - SCHEMA_VERSION
-      - IMS_ORG_ID
-      - DATASET_ID
+    type: object
     properties:
-      TENANT_ID:
-        type: string
-        description: "This ID is used to ensure that resources you create are properly namespaced and contained within your IMS Organization."
-      SCHEMA_ID:
-        type: string
-        description: "The ID of the schema that is created."
-      SCHEMA_VERSION:
-        type: string
-        description: "The version of the schema that is created."
-      IMS_ORG_ID:
-        type: string
-        description: "Your IMS Organization ID can be found under the integration details in the Adobe Developer Console."
-      DATASET_ID:
-        type: string
-        description: "The ID of the dataset that you want to publish to."
-      SOURCE_NAME:
-        type: string
-        description: "The optional name for your source. If this value is missing, the streaming message will automatically add the source ID from the streaming connection definition."
-
-    description: "The message that you want to ingest."
+      header:
+        type: object
+        properties:
+          schemaRef:
+            "$ref": "#/definitions/SchemaReference"
+          imsOrgId:
+            type: "string"
+            description: "Unique Identifier for your IMS Organization ({IMS_ORG})"
+          datasetId:
+            type: "string"
+            description: "The ID of the dataset that you want to publish to."
+          source:
+            type: object
+            properties:
+              name:
+                type: "string"
+                description: "The optional name for your source. If this value is missing, the streaming message will automatically add the source ID from the streaming connection definition."
+      body:
+        type: object
+        properties:
+          xdmMeta:
+            type: object
+            properties:
+              schemaRef:
+                "$ref": "#/definitions/SchemaReference"
+          xdmEntity:
+            type: object
+            additionalProperties: true
     example:
       header:
         schemaRef:
@@ -652,6 +655,14 @@ definitions:
             address: janedoe@example.com
             type: work
             status: active
+  SchemaReference:
+    type: object
+    properties:
+      contentType:
+        type: string
+      id:
+        type: string
+    title: SchemaReference
   File:
     type: "object"
     properties:
@@ -926,7 +937,9 @@ definitions:
       xactionId: "1532625558467:0001:13"
       receivedTimeMs: "1551307525735"
   BatchMessage:
-    type: object
+    type: array
+    items:
+      $ref: "#/definitions/streamingMessage"
     description: "The batch message to be published to Platform."
     example:
       {

--- a/acpdr/swagger-specs/ingest-api.yaml
+++ b/acpdr/swagger-specs/ingest-api.yaml
@@ -274,6 +274,11 @@ paths:
           required: true
           type: string
           in: header
+        - in: formData
+          name: body
+          type: file
+          description: Contents of the file.
+          x-mimetype: application/octet-stream
         - name: "batchId"
           in: "path"
           required: true

--- a/acpdr/swagger-specs/observability-insights.yaml
+++ b/acpdr/swagger-specs/observability-insights.yaml
@@ -5,7 +5,7 @@ info:
   description: >-
     * Service description:
       * The Observability Insights API is used to collect and expose metrics data from various components of Observability. It listens to events broadcasting on the data pipeline and collects metrics on resources and statistics on data ingestion.
-    
+
     * Related documentation:
       * [Observability Insights documentation](http://www.adobe.com/go/observability-overview-en)
 
@@ -23,8 +23,8 @@ info:
       * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
       * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
       * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.
-  
-    
+
+
   version: "1.0.0"
 basePath: /data/infrastructure/observability/insights
 host: platform.adobe.io
@@ -51,6 +51,10 @@ paths:
         - $ref: '#/parameters/id'
         - $ref: '#/parameters/dateRange'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "A successful response returns information on the metrics specified in the request path."
           schema:
@@ -77,8 +81,12 @@ paths:
           in: body
           schema:
             $ref: "#/definitions/metricsRequest"
-          
+
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "A successful response returns information on the metrics specified in the request payload."
           schema:
@@ -86,8 +94,8 @@ paths:
             properties:
               metricResponses:
                 $ref: "#/definitions/metricsResponses"
-      
-      
+
+
 definitions:
   metricsRequest:
     type: "object"
@@ -144,7 +152,7 @@ definitions:
         example: "dataSetId"
       value:
         type: string
-        example: "5edcfb2fbb642119194c7d94|5eddb21420f516191b7a8dad" 
+        example: "5edcfb2fbb642119194c7d94|5eddb21420f516191b7a8dad"
       groupBy:
         type: boolean
         example: true
@@ -288,7 +296,7 @@ definitions:
     example: null
   400error:
     type: object
-    allOf: 
+    allOf:
       - $ref: '#/definitions/observability.insights.error'
     example:
       errorCode: "OBS-4002"
@@ -310,6 +318,33 @@ definitions:
       details:
         type: "string"
         description: "A human-readable explanation specific to this occurrence of the problem."
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
 parameters:
   x-api-key:
     name: x-api-key
@@ -331,8 +366,8 @@ parameters:
     in: header
   authorization:
     name: Authorization
-    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ". 
-    For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
+    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ".
+      For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
     required: true
     type: string
     in: header

--- a/acpdr/swagger-specs/privacy-service.yaml
+++ b/acpdr/swagger-specs/privacy-service.yaml
@@ -16,7 +16,7 @@ info:
       - PLATFORM Gateway URL: https://<span>platform.adobe.io/
       - Base path for this API: /data/core/privacy
       - Example of a complete path: https://<span>platform.adobe.io/data/core/privacy/jobs
-    
+
     - Required headers:
       - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the guide on [getting started with the Privacy Service API](http://www.adobe.com/go/privacy-getting-started-en).
       - All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.
@@ -51,15 +51,27 @@ paths:
           schema:
             $ref: '#/definitions/PrivacySaleConsentResource'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '202':
           description: A successful response returns returns HTTP status 202 (Accepted) with no payload, indicating that the request was accepted by Privacy Service and is undergoing processing.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request is incomplete or malformed.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: You do not have access permissions for this endpoint.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The requested resource could not be found. Double-check that your ID values are accurate.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was an internal server error. Try the request again in a few minutes, and contact Adobe Support if the problem persists.
   /jobs:
     get:
@@ -124,17 +136,29 @@ paths:
           required: false
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of jobs under the provided regulation. Note that data for previously created jobs is only available for retrieval within 30 days of the job's completion date.
           schema:
             $ref: '#/definitions/PrivacyJobDetailsList'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request is incomplete or malformed.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: You do not have access permissions for this endpoint.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The requested resource could not be found. Double-check that your ID values are accurate.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was an internal server error. Try the request again in a few minutes, and contact Adobe Support if the problem persists.
     post:
       tags:
@@ -157,17 +181,29 @@ paths:
           schema:
             $ref: '#/definitions/PrivacyJobRequestDetails'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '202':
           description: The jobs were successfully created. The response body contains the details of the newly created privacy jobs.
           schema:
             $ref: '#/definitions/PrivacyJobCreateList'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request is incomplete or malformed.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: You do not have access permissions for this endpoint.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The requested resource could not be found. Double-check that your ID values are accurate.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was an internal server error. Try the request again in a few minutes, and contact Adobe Support if the problem persists.
   /jobs/{JOB_ID}:
     get:
@@ -183,17 +219,29 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the privacy job.
           schema:
             $ref: '#/definitions/PrivacyJobDetails'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request is incomplete or malformed.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: You do not have access permissions for this endpoint.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The requested resource could not be found. Double-check that your ID values are accurate.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was an internal server error. Try the request again in a few minutes, and contact Adobe Support if the problem persists.
 parameters:
   job-id:
@@ -227,6 +275,33 @@ parameters:
     type: string
     in: header
 definitions:
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
   PrivacySaleConsentDetails:
     type: object
     properties:

--- a/acpdr/swagger-specs/qs-api.yaml
+++ b/acpdr/swagger-specs/qs-api.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   version: "1.0"
   title: Query Service API
-  description: >- 
+  description: >-
     Experience Query Service gives you the ability to use standard SQL to query data on Adobe Experience Platform to support many different use cases. It is a serverless tool which allows you to join any datasets in Experience Data Lake and capture the query results as a new dataset for use in reporting, Data Science Workspace, or for ingestion into Real-time Customer Profile.
 
 
@@ -18,18 +18,18 @@ info:
       * PLATFORM Gateway URL: https://<span>platform.adobe.io/
       * Base path for this API: /data/foundation/query
       * Example of a complete path: https://<span>platform.adobe.io/data/foundation/query/queries
-    
+
     Required headers:
       * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
       * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
       * All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.
-  
+
 host: platform.adobe.io
 basePath: /data/foundation/query
 
 tags:
   - name: "Queries"
-    description: Queries let you use standard SQL to query data in Adobe Experience Platform. For example, you can join any number of datasets in Experience Data Lake and capture the results as a new dataset.  
+    description: Queries let you use standard SQL to query data in Adobe Experience Platform. For example, you can join any number of datasets in Experience Data Lake and capture the results as a new dataset.
   - name: "Connections"
     description: Retrieves connection parameters for the interactive interface.
   - name: "Schedules"
@@ -59,14 +59,22 @@ paths:
       - $ref: '#/parameters/x-request-id'
       - $ref: '#/parameters/User-Agent'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "Connection Parameters Response for interactive interface"
           schema:
             $ref: '#/definitions/connection_parameters'
 
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
 
@@ -94,16 +102,26 @@ paths:
         - $ref: '#/parameters/isPrevLink'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "Query List Response"
           schema:
             $ref: '#/definitions/query_list'
 
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not Found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
     post:
@@ -131,15 +149,25 @@ paths:
             $ref: '#/definitions/query_def'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: Query status
           schema:
             $ref: '#/definitions/query'
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Bad Request. The payload may be malformed, or the SQL statement has been found to be syntactically incorrect."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
   '/queries/{queryid}':
@@ -165,16 +193,26 @@ paths:
           type: string
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: Query status
           schema:
             $ref: '#/definitions/query'
 
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Query not found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
     patch:
@@ -215,15 +253,25 @@ paths:
         - $ref: '#/parameters/json-header'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: "Query termination request submitted successfully"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not found"
         409:
           description: "Query termination request failed because the job might already have terminated"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
   /schedules:
@@ -247,15 +295,25 @@ paths:
         - $ref: '#/parameters/User-Agent'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "Schedules List Response"
           schema:
             $ref: '#/definitions/schedules_list'
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not Found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
     post:
@@ -283,15 +341,25 @@ paths:
                $ref: '#/definitions/schedules_create_request'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: Schedules Response
           schema:
             $ref: '#/definitions/schedules'
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Bad Request. The payload may be malformed, or the SQL statement has been found to be syntactically incorrect."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
   '/schedules/{schedulesId}':
@@ -317,15 +385,25 @@ paths:
           type: string
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: Schedules Response
           schema:
             $ref: '#/definitions/schedules'
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Query not found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
     patch:
@@ -364,15 +442,27 @@ paths:
                   $ref: '#/definitions/schedule_patch_operation'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: "Request to patch accepted"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Schedule already in the state request OR Schedule is in Inactive state. Please try after sometime."
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not Found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
     delete:
@@ -397,15 +487,27 @@ paths:
           type: string
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: "Schedule deleted successfully"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Please disable the schedule before requesting delete operation OR There are active run(s) for this schedule, please wait for completion before requesting delete operation"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not Found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
   '/schedules/{schedulesId}/runs':
@@ -435,15 +537,25 @@ paths:
           type: string
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: Schedules Run Response
           schema:
             $ref: '#/definitions/schedules_run_list'
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not Found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
     post:
@@ -470,15 +582,27 @@ paths:
           type: string
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: "Request to trigger run of a scheduled query accepted"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Schedule is disabled. Immediate run cannot be triggered"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not Found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
   '/schedules/{schedulesId}/runs/{runId}':
@@ -510,16 +634,26 @@ paths:
             type: string
 
         responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           200:
             description: Schedules Run Response
             schema:
               $ref: '#/definitions/schedules_run_details'
           401:
+            schema:
+              $ref: '#/definitions/ErrorResponse'
             description: "Unauthorized"
           404:
+            schema:
+              $ref: '#/definitions/ErrorResponse'
             description: "Not Found"
           500:
-            description: "Internal Server Error"
+            schema:
+              $ref: '#/definitions/ErrorResponse'
+              description: "Internal Server Error"
 
       patch:
         operationId: "cancel_schedule_run"
@@ -563,14 +697,24 @@ paths:
                     - cancel
 
         responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           202:
             description: "Request to cancel run of a scheduled query accepted"
           401:
-            description: "Unauthorized"
+            schema:
+              $ref: '#/definitions/ErrorResponse'
+              description: "Unauthorized"
           404:
-            description: "Not Found"
+            schema:
+              $ref: '#/definitions/ErrorResponse'
+              description: "Not Found"
           500:
-            description: "Internal Server Error"
+            schema:
+              $ref: '#/definitions/ErrorResponse'
+              description: "Internal Server Error"
 
   /query-templates:
     get:
@@ -594,16 +738,26 @@ paths:
         - $ref: '#/parameters/template_property'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: "Success"
           schema:
             $ref: '#/definitions/query_template_list'
 
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not Found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
 
     post:
@@ -631,13 +785,21 @@ paths:
                $ref: '#/definitions/query_template_def'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: Success
           schema:
             $ref: '#/definitions/query_template'
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
   '/query-templates/count':
     get:
@@ -657,17 +819,27 @@ paths:
         - $ref: '#/parameters/template_count_property'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: Success
           schema:
             $ref: '#/definitions/template_count'
 
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not found"
         500:
-          description: "Internal Server Error"      
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "Internal Server Error"
   '/query-templates/{queryTemplateId}':
      get:
       operationId: "get_query_template"
@@ -691,16 +863,26 @@ paths:
           type: string
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: Success
           schema:
             $ref: '#/definitions/query_template'
 
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
      put:
       operationId: "update_query_template"
@@ -733,13 +915,21 @@ paths:
                $ref: '#/definitions/query_template_def'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: Success
           schema:
             $ref: '#/definitions/query_template'
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
      delete:
       operationId: "delete_query_template"
@@ -763,20 +953,27 @@ paths:
           type: string
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: Query Template Delete
           schema:
             $ref: '#/definitions/query_template_delete'
 
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Unauthorized"
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Not found"
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Internal Server Error"
-
-
-
 parameters:
   authorization:
     name: Authorization
@@ -981,6 +1178,33 @@ parameters:
     description: "type of the client making HTTP API request"
 
 definitions:
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
   query_def:
     type: object
     description: Definition of a query to be submitted
@@ -1208,7 +1432,7 @@ definitions:
           href:
             type: string
             description: "URI to call to soft-delete this query. Soft-deleting stops returning this query on
-            GET /queries, but it does not delete it from the system."
+              GET /queries, but it does not delete it from the system."
           method:
             type: string
             description: the HTTP method to use
@@ -1463,7 +1687,7 @@ definitions:
 
   schedules:
     type: object
-    required: 
+    required:
       - id
       - userId
       - state

--- a/acpdr/swagger-specs/reactor.yaml
+++ b/acpdr/swagger-specs/reactor.yaml
@@ -2,18 +2,18 @@ swagger: '2.0'
 info:
   version: '1.0'
   title: Reactor API
-  description: >- 
+  description: >-
     The Reactor API is used to programmatically manage resources and develop tag extensions in Adobe Experience Platform.
-  
-  
+
+
     Related documentation:
       * [Tags overview and UI documentation](https://adobe.com/go/launch_help_en)
       * [Reactor API documentation](https://adobe.com/go/reactor-api-overview)
-  
+
     API paths:
       * Reactor Gateway URL: https://<span>reactor.adobe.io
       * Example of a complete path for making a call to "/properties": https://<span>reactor.adobe.io/properties
-    
+
     Required headers:
       * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/launch-authentication-en).
       * All GET requests to the Reactor API require an `Accept` header to determine what data is returned by the system. In most cases, this value will be "application/vnd.api+json;revision=#" (where "#" is the revision number of the resource you want to retrieve, e.g. "1").
@@ -53,7 +53,7 @@ tags:
   - name: "Profiles"
     description: A profile represents a tags user. Platform does not maintain its own database of users and permissions, it instead relies on Adobe IDs managed by Adobe’s company-wide Identity Management System (IMS). A profile contains all the information about the logged-in user, including all the Adobe Orgs to which they belong, the product profiles they belong to within each Org, and the rights they have from each product profile.
   - name: "Search"
-    description: The search endpoint provides a way to find resources matching a desired criteria, expressed as a query. All queries are scoped to your current company and accessible properties. 
+    description: The search endpoint provides a way to find resources matching a desired criteria, expressed as a query. All queries are scoped to your current company and accessible properties.
 consumes:
   - application/vnd.api+json;revision=1
 produces:
@@ -77,6 +77,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of companies, including their IDs and attributes.
           schema:
@@ -153,8 +157,12 @@ paths:
                   "total_pages": 1
                   "total_count": 2
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/companies/{COMPANY_ID}':
     get:
@@ -174,6 +182,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the company.
           schema:
@@ -213,8 +225,12 @@ paths:
                       - "manage_properties"
                       - "manage_app_configurations"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/companies/{COMPANY_ID}/properties':
     get:
@@ -242,6 +258,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array, listing the properties belonging to the specified company.
           schema:
@@ -373,8 +393,12 @@ paths:
                   "total_pages": 1
                   "total_count": 2
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -404,6 +428,10 @@ paths:
                   "platform": "web"
                 "type": "properties"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created property.
           schema:
@@ -469,8 +497,12 @@ paths:
                     - "manage_extensions"
                     - "publish"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/companies/{COMPANY_ID}/app_configurations':
     get:
@@ -498,6 +530,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array, listing the app configurations belonging to the specified company.
           schema:
@@ -531,8 +567,12 @@ paths:
                   "total_pages": 1
                   "total_count": 3
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -568,6 +608,10 @@ paths:
                     "teamId": "team_id"
                 "type": "app_configurations"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created app configuration.
           schema:
@@ -594,8 +638,12 @@ paths:
                   "company": "https://reactor.adobe.io/companies/CO2bf094214ffd4785bb4bcf88c952a7c1"
                   "self": "https://reactor.adobe.io/app_configurations/AC40c339ab80d24c958b90d67b698602eb"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}':
     get:
@@ -615,6 +663,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the property.
           schema:
@@ -680,8 +732,12 @@ paths:
                     - "manage_extensions"
                     - "publish"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -690,9 +746,9 @@ paths:
       description: >-
         **Note**:
 
-        
+
         When updating a property, its ID must be provided in both the request path and the request payload, as shown in the example below. These IDs must match in order for the call to be successful.
-        
+
 
         The following attributes can be edited for a property:
 
@@ -735,6 +791,10 @@ paths:
               "id": "PR541dbb24bad54dceb04710d7a9e7a740"
               "type": "properties"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated property.
           schema:
@@ -800,8 +860,12 @@ paths:
                     - "manage_extensions"
                     - "publish"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     delete:
       tags:
@@ -817,11 +881,19 @@ paths:
       - $ref: '#/parameters/x-api-key'
       - $ref: '#/parameters/x-gw-ims-org-id'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         204:
           description: A successful response returns HTTP status 204 (No Content).
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/app_configurations/{CONFIG_ID}':
     get:
@@ -841,6 +913,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the app configuration.
           schema:
@@ -868,8 +944,12 @@ paths:
                   "company": "https://reactor.adobe.io/companies/CO2bf094214ffd4785bb4bcf88c952a7c1"
                   "self": "https://reactor.adobe.io/app_configurations/AC40c339ab80d24c958b90d67b698602eb"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -898,6 +978,10 @@ paths:
               "id": "AC40c339ab80d24c958b90d67b698602eb"
               "type": "app_configurations"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated app configuration.
           schema:
@@ -924,8 +1008,12 @@ paths:
                   "company": "https://reactor.adobe.io/companies/CO2bf094214ffd4785bb4bcf88c952a7c1"
                   "self": "https://reactor.adobe.io/app_configurations/AC40c339ab80d24c958b90d67b698602eb"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     delete:
       tags:
@@ -941,11 +1029,19 @@ paths:
       - $ref: '#/parameters/x-api-key'
       - $ref: '#/parameters/x-gw-ims-org-id'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         204:
           description: A successful response returns HTTP status 204 (No Content).
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/app_configurations/{CONFIG_ID}/company':
     get:
@@ -962,6 +1058,10 @@ paths:
       - $ref: '#/parameters/x-api-key'
       - $ref: '#/parameters/x-gw-ims-org-id'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the company that owns the app configuration.
           schema:
@@ -1001,9 +1101,13 @@ paths:
                       - "manage_properties"
                       - "manage_app_configurations"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred." 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}/company':
     get:
       tags:
@@ -1019,6 +1123,10 @@ paths:
       - $ref: '#/parameters/x-api-key'
       - $ref: '#/parameters/x-gw-ims-org-id'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the company that owns the property.
           schema:
@@ -1058,8 +1166,12 @@ paths:
                       - "manage_properties"
                       - "manage_app_configurations"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}/callbacks':
     get:
@@ -1082,11 +1194,15 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of callbacks belonging to the specified property.
           schema:
             example:
-              "data": 
+              "data":
                 - "id": "CB26edef8d709243579589107bcda034da"
                   "type": "callbacks"
                   "attributes":
@@ -1113,8 +1229,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -1145,6 +1265,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created callback.
           schema:
@@ -1169,8 +1293,12 @@ paths:
                   "property": "https://reactor.adobe.io/properties/PR5e22de986a7c4070965e7546b2bb108d"
                   "self": "https://reactor.adobe.io/callbacks/CB32d8f23d5ee548278d32076af4c442a0"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}/data_elements':
     get:
@@ -1199,6 +1327,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of data elements belonging to the specified property.
           schema:
@@ -1278,8 +1410,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -1315,6 +1451,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created data element.
           schema:
@@ -1387,9 +1527,13 @@ paths:
                 "meta":
                   "latest_revision_number": 0
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred." 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}/environments':
     get:
       tags:
@@ -1414,6 +1558,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of environments belonging to the specified property.
           schema:
@@ -1476,8 +1624,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -1512,6 +1664,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created environment.
           schema:
@@ -1567,8 +1723,12 @@ paths:
                 "meta":
                   "archive_encrypted": false
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}/extensions':
     get:
@@ -1599,6 +1759,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of extensions belonging to the specified property.
           schema:
@@ -1671,8 +1835,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -1705,6 +1873,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created extension.
           schema:
@@ -1770,9 +1942,13 @@ paths:
                 "meta":
                   "latest_revision_number": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."    
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}/hosts':
     get:
       tags:
@@ -1802,6 +1978,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of hosts belonging to the specified property.
           schema:
@@ -1837,8 +2017,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -1873,6 +2057,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created host.
           schema:
@@ -1901,9 +2089,13 @@ paths:
                   "property": "https://reactor.adobe.io/properties/PRb25a704c0b7c4562835ccdf96d3afd31"
                   "self": "https://reactor.adobe.io/hosts/HT69bfe634dead4a9a8c659f5d4d94cecd"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."    
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}/libraries':
     get:
       tags:
@@ -1928,6 +2120,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of libraries belonging to the specified property.
           schema:
@@ -1991,8 +2187,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -2021,6 +2221,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created library.
           schema:
@@ -2077,8 +2281,12 @@ paths:
                   "build_status": null
                   "build_required_detail": "No build found since last state change"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}/rules':
     get:
@@ -2108,6 +2316,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of rules belonging to the specified property.
           schema:
@@ -2166,8 +2378,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -2196,6 +2412,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created rule.
           schema:
@@ -2247,8 +2467,12 @@ paths:
                 "meta":
                   "latest_revision_number": 0
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/callbacks/{CALLBACK_ID}':
     get:
@@ -2268,6 +2492,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the callback.
           schema:
@@ -2292,8 +2520,12 @@ paths:
                   "property": "https://reactor.adobe.io/properties/PRb513bbab52114573ac87f9848eea6ead"
                   "self": "https://reactor.adobe.io/callbacks/CBeef389cee8d84e69acef8665e4dcbef6"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -2302,13 +2534,13 @@ paths:
       description: >-
         **Note**:
 
-        
+
         When updating a callback, its ID must be provided in both the request path and the request payload, as shown in the example below. These IDs must match in order for the call to be successful.
 
 
         When updating an app configuration, its ID must be provided in both the request path and the request payload, as shown in the example below. These IDs must match in order for the call to be successful.
 
-        
+
         The following attributes are editable for a callback:
 
         * `url`
@@ -2341,6 +2573,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated callback.
           schema:
@@ -2366,8 +2602,12 @@ paths:
                   "property": "https://reactor.adobe.io/properties/PR0a8ef3ca31dc456a8566e9288960bd79"
                   "self": "https://reactor.adobe.io/callbacks/CB4310904d415549888cc9e31ebe1e1e45"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     delete:
       tags:
@@ -2385,11 +2625,19 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         204:
           description: A successful response returns HTTP status 204 (No Content).
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/data_elements/{DATA_ELEMENT_ID}':
     get:
@@ -2409,6 +2657,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the data element.
           schema:
@@ -2481,8 +2733,12 @@ paths:
                 "meta":
                   "latest_revision_number": 0
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -2491,30 +2747,30 @@ paths:
       description: >-
         **Note**:
 
-        
+
         Revising a data element creates a new revision of the data element which is assigned its own ID. The original data element may be discovered via the origin link. Revising a data element is achieved by supplying a `meta` attribute containing an `action` property with the value `revise` (`"action": "revise"`). Excluding this property will update the current revision of the data element without creating a new one.
 
 
         When updating a data element, its ID must be provided in both the request path and the request payload, as shown in the example below. These IDs must match in order for the call to be successful.
-        
+
 
         Attributes to be updated must be included in the `attributes` object in the payload. Editable attributes for a data element include the following:
-        
+
         * `clean_text`
-        
+
 
         * `default_value`
-        
+
         * `delegate_descriptor_id`
-        
+
         * `enabled`
-        
+
         * `force_lower_case`
-        
+
         * `name`
-        
+
         * `settings`
-        
+
         * `storage_duration`
       parameters:
         - name: DATA_ELEMENT_ID
@@ -2541,6 +2797,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated data element or its new revision.
           schema:
@@ -2612,8 +2872,12 @@ paths:
                 "meta":
                   "latest_revision_number": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/environments/{ENVIRONMENT_ID}':
     get:
@@ -2633,6 +2897,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the environment.
           schema:
@@ -2688,8 +2956,12 @@ paths:
                 "meta":
                   "archive_encrypted": false
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -2698,22 +2970,22 @@ paths:
       description: >-
         **Note**:
 
-        
+
         When updating or revising a rule, its ID must be provided in both the request path and the request payload, as shown in the example below. These IDs must match in order for the call to be successful.
 
-        
+
         Attributes to be updated must be included in the `attributes` object in the payload. Editable attributes for an environment include the following:
-        
+
 
         * `archive`
-        
+
 
         * `archive_passphrase`
-        
+
         * `include_debug_library`
-        
+
         * `name`
-        
+
         * `path`
       parameters:
         - name: ENVIRONMENT_ID
@@ -2738,6 +3010,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated environment.
           schema:
@@ -2793,9 +3069,13 @@ paths:
                 "meta":
                   "archive_encrypted": false
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."  
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
     delete:
       tags:
         - Environments
@@ -2812,13 +3092,21 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         204:
           description: A successful response returns HTTP status 204 (No Content).
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
-  '/environments/{ENVIRONMENT_ID}/builds':  
+  '/environments/{ENVIRONMENT_ID}/builds':
     get:
       tags:
         - Environments
@@ -2836,6 +3124,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of builds that use the specified environment.
           schema:
@@ -2893,8 +3185,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/environments/{ENVIRONMENT_ID}/host':
     get:
@@ -2914,6 +3210,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the environment's associated host.
           schema:
@@ -2942,8 +3242,12 @@ paths:
                   "property": "https://reactor.adobe.io/properties/PR50586546f7764fc59997342b8ff7647c"
                   "self": "https://reactor.adobe.io/hosts/HT621241cf4fbb4f7da5b6415ee1b15ac0"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/environments/{ENVIRONMENT_ID}/relationships/host':
     get:
@@ -2963,6 +3267,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the host relationship for the specified environment.
           schema:
@@ -2974,8 +3282,12 @@ paths:
                 "related": "https://reactor.adobe.io/environments/ENd9e6690785d14805b046d7d0fafab23a/host"
                 "self": "https://reactor.adobe.io/environments/ENd9e6690785d14805b046d7d0fafab23a/relationships/host"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/environments/{ENVIRONMENT_ID}/library':
     get:
@@ -2995,6 +3307,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the environment's associated library.
           schema:
@@ -3054,8 +3370,12 @@ paths:
                   "build_status": null
                   "build_required_detail": "No build found since last state change"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/environments/{ENVIRONMENT_ID}/property':
     get:
@@ -3075,6 +3395,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the environment's associated property.
           schema:
@@ -3140,8 +3464,12 @@ paths:
                     - "manage_extensions"
                     - "publish"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/extension_packages':
     get:
@@ -3160,10 +3488,14 @@ paths:
         - $ref: '#/parameters/status'
         - $ref: '#/parameters/platform'
         - $ref: '#/parameters/version'
-        
+
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of extension packages, including their IDs and attributes.
           schema:
@@ -3243,8 +3575,12 @@ paths:
                   "total_pages": 1
                   "total_count": 8
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -3261,12 +3597,16 @@ paths:
           required: true
           description: The extension package archive file.
           type: file
-      
+
       consumes:
-      - multipart/form-data    
+      - multipart/form-data
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created extension package.
           schema:
@@ -3301,8 +3641,12 @@ paths:
                 "links":
                   "self": "https://reactor.adobe.io/extension_packages/EP10bb503178694d73bc0cd84387b82172"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/extension_packages/{EXTENSION_PACKAGE_ID}':
     get:
@@ -3322,6 +3666,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the extension package.
           schema:
@@ -3563,8 +3911,12 @@ paths:
                 "links":
                   "self": "https://reactor.adobe.io/extension_packages/EP75db2452065b44e2b8a38ca883ce369a"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -3586,12 +3938,16 @@ paths:
           required: true
           description: The extension package archive file.
           type: file
-      
+
       consumes:
-      - multipart/form-data    
+      - multipart/form-data
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated extension package.
           schema:
@@ -3626,8 +3982,12 @@ paths:
                 "links":
                   "self": "https://reactor.adobe.io/extension_packages/EP0393ce01ac3540acb78f103d8e58a5a0"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -3638,11 +3998,11 @@ paths:
 
 
         Once you have completed testing your extension package you can release it privately. This makes it available to any property within your company. After you have released privately, you can begin the public release process by filling out the [Public Release Request Form](https://adobe.allegiancetech.com/cgi-bin/qwebcorporate.dll?idx=7DRB5U).
-          
+
 
         A private release is achieved by supplying an `action` with a value of `release_private` in the JSON payload's `meta` object.
-        
-        
+
+
         To discontinue a package, you must supply an `attributes` object in the payload, containing a `discontinued` property with a value of `true`.
 
 
@@ -3671,6 +4031,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated extension package.
           schema:
@@ -3912,9 +4276,13 @@ paths:
                 "links":
                   "self": "https://reactor.adobe.io/extension_packages/EP75db2452065b44e2b8a38ca883ce369a"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."  
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
   '/extension_packages/{EXTENSION_PACKAGE_ID}/versions':
     get:
       tags:
@@ -3933,6 +4301,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of each version of the extension package.
           schema:
@@ -4181,8 +4553,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/extensions/{EXTENSION_ID}':
     get:
@@ -4202,6 +4578,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the extension.
           schema:
@@ -4267,8 +4647,12 @@ paths:
                 "meta":
                   "latest_revision_number": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -4309,6 +4693,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the new revision for the extension.
           schema:
@@ -4374,9 +4762,13 @@ paths:
                 "meta":
                   "latest_revision_number": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."  
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
     delete:
       tags:
         - Extensions
@@ -4393,11 +4785,19 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         204:
           description: A successful response returns HTTP status 204 (No Content).
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/extensions/{EXTENSION_ID}/extension_package':
     get:
@@ -4417,6 +4817,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the extension package associated with the specified extension.
           schema:
@@ -4658,8 +5062,12 @@ paths:
                 "links":
                   "self": "https://reactor.adobe.io/extension_packages/EP75db2452065b44e2b8a38ca883ce369a"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/extensions/{EXTENSION_ID}/libraries':
     get:
@@ -4679,6 +5087,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of libraries that are attached to the specified extension.
           schema:
@@ -4742,8 +5154,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/extensions/{EXTENSION_ID}/property':
     get:
@@ -4763,6 +5179,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the specified extension's property.
           schema:
@@ -4828,8 +5248,12 @@ paths:
                     - "manage_extensions"
                     - "publish"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/extensions/{EXTENSION_ID}/origin':
     get:
@@ -4849,6 +5273,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the specified extension's origin.
           schema:
@@ -4914,8 +5342,12 @@ paths:
                 "meta":
                   "latest_revision_number": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/extensions/{EXTENSION_ID}/revisions':
     get:
@@ -4935,6 +5367,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of revisions for the specified extension.
           schema:
@@ -5066,8 +5502,12 @@ paths:
                   "total_pages": 1
                   "total_count": 2
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/hosts/{HOST_ID}':
     get:
@@ -5087,6 +5527,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the host.
           schema:
@@ -5115,8 +5559,12 @@ paths:
                   "property": "https://reactor.adobe.io/properties/PRd7cf174259f34057b5c435ef873a79bf"
                   "self": "https://reactor.adobe.io/hosts/HT5d90148e72224224aac9bc0b01498b84"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -5128,47 +5576,47 @@ paths:
 
         When updating or revising a rule, its ID must be provided in both the request path and the request payload, as shown in the example below. These IDs must match in order for the call to be successful.
 
-        
+
         The following attributes can be edited for a host:
-        
+
          * `encrypted_private_key`
-        
+
 
         * `string`
-        
+
         * `optional`
-        
+
         * `name`
-        
+
         * `string`
-        
+
         * `optional`
-        
+
         * `path`
-        
+
         * `string`
-        
+
         * `optional`
-        
+
         * `port`
-        
+
         * `integer`
-        
+
         * `optional`
-        
+
         * `server`
-        
+
         * `string`
-        
+
         * `optional`
-        
+
         * `type_of`
-        
+
         * `string`
-        
+
         * `optional`
-        
-        * `username`     
+
+        * `username`
       parameters:
         - name: HOST_ID
           in: "path"
@@ -5192,6 +5640,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated host.
           schema:
@@ -5220,9 +5672,13 @@ paths:
                   "property": "https://reactor.adobe.io/properties/PR8f240526f7b54a4dbd46965e79519fde"
                   "self": "https://reactor.adobe.io/hosts/HTb14e136a6fe147459b298a4645d2a6f5"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."  
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
     delete:
       tags:
         - Hosts
@@ -5239,11 +5695,19 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         204:
           description: A successful response returns HTTP status 204 (No Content).
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/hosts/{HOST_ID}/property':
     get:
@@ -5263,6 +5727,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the property that owns the host.
           schema:
@@ -5328,8 +5796,12 @@ paths:
                     - "manage_extensions"
                     - "publish"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}':
     get:
@@ -5349,6 +5821,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the library.
           schema:
@@ -5405,13 +5881,17 @@ paths:
                   "build_status": null
                   "build_required_detail": "No build found since last state change"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
         - Libraries
-      summary: "Update a library by ID."  
+      summary: "Update a library by ID."
       description: >-
         **Note**:
 
@@ -5425,7 +5905,7 @@ paths:
         To transition the library between states, the payload must include a `meta` object, containing a single `action` property whose value represents the specific transition action. The available actions for a library depend on its current publishing state. See the API guide on [transitioning a library](https://developer.adobelaunch.com/api/reference/1.0/libraries/transition/) for details on the available actions for each library state.
 
 
-        When updating a library, its ID must be provided in both the request path and the request payload, as shown in the example below. These IDs must match in order for the call to be successful.        
+        When updating a library, its ID must be provided in both the request path and the request payload, as shown in the example below. These IDs must match in order for the call to be successful.
       parameters:
         - name: LIBRARY_ID
           in: "path"
@@ -5451,6 +5931,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated library library.
           schema:
@@ -5509,9 +5993,13 @@ paths:
                   "build_status": null
                   "build_required_detail": "No build found since last state change"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."  
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
     delete:
       tags:
         - Libraries
@@ -5528,11 +6016,19 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         204:
           description: A successful response returns HTTP status 204 (No Content).
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/property':
     get:
@@ -5552,6 +6048,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the property associated with the specified library.
           schema:
@@ -5617,8 +6117,12 @@ paths:
                     - "manage_extensions"
                     - "publish"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/builds':
     get:
@@ -5643,6 +6147,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of builds belonging to the specified library.
           schema:
@@ -5700,8 +6208,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -5721,6 +6233,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created build.
           schema:
@@ -5771,8 +6287,12 @@ paths:
                   "archive": false
                   "host_type_of": "akamai"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/environment':
     get:
@@ -5792,6 +6312,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the environment associated with the specified library.
           schema:
@@ -5849,8 +6373,12 @@ paths:
                 "meta":
                   "archive_encrypted": false
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/upstream_library':
     get:
@@ -5870,6 +6398,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the upstream library.
           schema:
@@ -5928,8 +6460,12 @@ paths:
                   "build_status": null
                   "build_required_detail": "No build found since last state change"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/data_elements':
     get:
@@ -5949,6 +6485,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of data elements related to the specified library.
           schema:
@@ -6028,8 +6568,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/relationships/data_elements':
     get:
@@ -6049,6 +6593,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of data element relationships attached to the specified library.
           schema:
@@ -6060,8 +6608,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LB4743967474414e538557b41d3b47fb20/data_elements"
                 "self": "https://reactor.adobe.io/libraries/LB4743967474414e538557b41d3b47fb20/relationships/data_elements"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -6072,8 +6624,8 @@ paths:
 
 
         * `id`: The ID of the data element that you want to add.
-        
-        
+
+
         * `type`: Must be set to "data_elements".
       parameters:
         - name: LIBRARY_ID
@@ -6096,6 +6648,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the newly created relationship.
           schema:
@@ -6107,8 +6663,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LB09eca17e012842b49466506f419283a7/data_elements"
                 "self": "https://reactor.adobe.io/libraries/LB09eca17e012842b49466506f419283a7/relationships/data_elements"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -6119,8 +6679,8 @@ paths:
 
 
         * `id`: The ID of the data element that you want to include in the library.
-        
-        
+
+
         * `type`: Must be set to "data_elements".
       parameters:
         - name: LIBRARY_ID
@@ -6143,6 +6703,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the updated relationship.
           schema:
@@ -6154,8 +6718,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LBdfaf4cd8affe40fea0e7f267652df6db/data_elements"
                 "self": "https://reactor.adobe.io/libraries/LBdfaf4cd8affe40fea0e7f267652df6db/relationships/data_elements"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     delete:
       tags:
@@ -6182,6 +6750,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the removed relationship.
           schema:
@@ -6193,8 +6765,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LBdfaf4cd8affe40fea0e7f267652df6db/data_elements"
                 "self": "https://reactor.adobe.io/libraries/LBdfaf4cd8affe40fea0e7f267652df6db/relationships/data_elements"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/relationships/environment':
     get:
@@ -6214,6 +6790,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the environment relationship attached to the specified library.
           schema:
@@ -6225,8 +6805,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LB85b4873543034b5e93f5248645d22806/environment"
                 "self": "https://reactor.adobe.io/libraries/LB85b4873543034b5e93f5248645d22806/relationships/environment"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -6253,6 +6837,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the established relationship.
           schema:
@@ -6264,8 +6852,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LBdd2f55e9c3bb4ce0a582a0b0c586a6f5/environment"
                 "self": "https://reactor.adobe.io/libraries/LBdd2f55e9c3bb4ce0a582a0b0c586a6f5/relationships/environment"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     delete:
       tags:
@@ -6284,6 +6876,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the removed relationship.
           schema:
@@ -6293,8 +6889,12 @@ paths:
                 "self": "https://reactor.adobe.io/libraries/LBe3a53b394dad4e8381317ecda26b96be/relationships/environment"
                 "related": "https://reactor.adobe.io/libraries/LBe3a53b394dad4e8381317ecda26b96be/environment"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/extensions':
     get:
@@ -6314,6 +6914,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of extensions associated with the specified library.
           schema:
@@ -6386,8 +6990,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/relationships/extensions':
     get:
@@ -6407,6 +7015,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of extension relationship objects attached to the specified library.
           schema:
@@ -6418,8 +7030,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LB8939966ac6214d4bb604d06726a7e8b3/extensions"
                 "self": "https://reactor.adobe.io/libraries/LB8939966ac6214d4bb604d06726a7e8b3/relationships/extensions"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -6430,8 +7046,8 @@ paths:
 
 
         * `id`: The ID of the extension that you want to include in the library.
-        
-        
+
+
         * `type`: Must be set to "extensions".
       parameters:
         - name: LIBRARY_ID
@@ -6454,6 +7070,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of extension relationships attached to the library, including those just added.
           schema:
@@ -6465,8 +7085,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LBce8f03e3b0704cad8689dcfd0a9cd57e/extensions"
                 "self": "https://reactor.adobe.io/libraries/LBce8f03e3b0704cad8689dcfd0a9cd57e/relationships/extensions"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -6477,8 +7101,8 @@ paths:
 
 
         * `id`: The ID of the extension that you want to include in the library.
-        
-        
+
+
         * `type`: Must be set to "extensions".
       parameters:
         - name: LIBRARY_ID
@@ -6501,6 +7125,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of the library's replaced extensions.
           schema:
@@ -6512,8 +7140,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LBdbc7c49ac8f040bc9576db26b127444d/extensions"
                 "self": "https://reactor.adobe.io/libraries/LBdbc7c49ac8f040bc9576db26b127444d/relationships/extensions"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     delete:
       tags:
@@ -6532,6 +7164,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the updated list of extensions for the library.
           schema:
@@ -6541,8 +7177,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LB6692d815328148a38e01c6acf6302f8b/extensions"
                 "self": "https://reactor.adobe.io/libraries/LB6692d815328148a38e01c6acf6302f8b/relationships/extensions"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/rules':
     get:
@@ -6562,6 +7202,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of rules associated with the specified library.
           schema:
@@ -6620,8 +7264,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/relationships/rules':
     get:
@@ -6641,6 +7289,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of rule relationship objects attached to the specified library.
           schema:
@@ -6652,8 +7304,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LB001b2bb35a774102bef9c75fc964de01/rules"
                 "self": "https://reactor.adobe.io/libraries/LB001b2bb35a774102bef9c75fc964de01/relationships/rules"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -6664,8 +7320,8 @@ paths:
 
 
         * `id`: The ID of the rule that you want to include in the library.
-        
-        
+
+
         * `type`: Must be set to "rules".
       parameters:
         - name: LIBRARY_ID
@@ -6688,6 +7344,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of rule relationships attached to the library, including those just added.
           schema:
@@ -6699,8 +7359,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LB40cfb51ac87647a1a09672a3e7a0f677/rules"
                 "self": "https://reactor.adobe.io/libraries/LB40cfb51ac87647a1a09672a3e7a0f677/relationships/rules"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -6711,8 +7375,8 @@ paths:
 
 
         * `id`: The ID of the rule that you want to include in the library.
-        
-        
+
+
         * `type`: Must be set to "rules".
       parameters:
         - name: LIBRARY_ID
@@ -6735,6 +7399,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of the library's replaced rules.
           schema:
@@ -6746,8 +7414,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LB874f21e6ea0d4e6a972a5409b4d38635/rules"
                 "self": "https://reactor.adobe.io/libraries/LB874f21e6ea0d4e6a972a5409b4d38635/relationships/rules"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     delete:
       tags:
@@ -6774,6 +7446,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the updated list of rules for the library.
           schema:
@@ -6783,8 +7459,12 @@ paths:
                 "related": "https://reactor.adobe.io/libraries/LBbde5759742844fe59458ca0c988ecd61/rules"
                 "self": "https://reactor.adobe.io/libraries/LBbde5759742844fe59458ca0c988ecd61/relationships/rules"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/builds/{BUILD_ID}':
     get:
@@ -6804,6 +7484,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the build.
           schema:
@@ -6854,8 +7538,12 @@ paths:
                   "archive": false
                   "host_type_of": "akamai"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
@@ -6886,6 +7574,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the build.
           schema:
@@ -6936,8 +7628,12 @@ paths:
                   "archive": false
                   "host_type_of": "akamai"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rules/{RULE_ID}':
     get:
@@ -6957,6 +7653,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the rule.
           schema:
@@ -7008,27 +7708,31 @@ paths:
                 "meta":
                   "latest_revision_number": 0
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     patch:
       tags:
         - Rules
-      summary: "Update or revise a rule by ID." 
+      summary: "Update or revise a rule by ID."
       description: >-
         **Note**:
 
-        
+
         Revising a rule creates a new revision of the rule which is assigned its own ID. The original rule may be discovered via the origin link. Revising a rule is achieved by supplying a `meta` attribute containing an `action` property with the value `revise` (`"action": "revise"`). Excluding this property will update the current revision of the rule without creating a new one.
-        
+
 
         When updating or revising a rule, its ID must be provided in both the request path and the request payload, as shown in the example below. These IDs must match in order for the call to be successful.
 
 
         Attributes to be updated must be included in the `attributes` object in the payload. Editable attributes for a rule include the following:
-        
+
         * `enabled`
-        
+
 
         * `name`
       parameters:
@@ -7054,6 +7758,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the new revision for the rule.
           schema:
@@ -7105,9 +7813,13 @@ paths:
                 "meta":
                   "latest_revision_number": 0
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."  
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
     delete:
       tags:
         - Rules
@@ -7124,11 +7836,19 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         204:
           description: A successful response returns HTTP status 204 (No Content).
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rules/{RULE_ID}/rule_components':
     get:
@@ -7159,6 +7879,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of rule components attached to the rule.
           schema:
@@ -7234,8 +7958,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -7279,6 +8007,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: A successful response returns the details of the newly created rule component.
           schema:
@@ -7347,8 +8079,12 @@ paths:
                 "meta":
                   "latest_revision_number": 0
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rules/{RULE_ID}/libraries':
     get:
@@ -7368,6 +8104,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of libraries related to the specified rule.
           schema:
@@ -7431,8 +8171,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rules/{RULE_ID}/property':
     get:
@@ -7452,6 +8196,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the specified rule's property.
           schema:
@@ -7517,8 +8265,12 @@ paths:
                     - "manage_extensions"
                     - "publish"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rules/{RULE_ID}/origin':
     get:
@@ -7538,6 +8290,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the specified rule's origin.
           schema:
@@ -7589,8 +8345,12 @@ paths:
                 "meta":
                   "latest_revision_number": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rules/{RULE_ID}/revisions':
     get:
@@ -7610,6 +8370,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of revisions for the specified rule.
           schema:
@@ -7713,8 +8477,12 @@ paths:
                   "total_pages": 1
                   "total_count": 2
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rules/{RULE_ID}/rule_component_notes':
     get:
@@ -7739,6 +8507,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of notes attached to the rule components of the specified rule.
           schema:
@@ -7769,8 +8541,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rule_components/{RULE_COMPONENT_ID}':
     get:
@@ -7790,6 +8566,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the rule component.
           schema:
@@ -7858,17 +8638,21 @@ paths:
                 "meta":
                   "latest_revision_number": 0
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."    
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
     patch:
       tags:
         - Rule components
-      summary: "Update a rule component by ID." 
+      summary: "Update a rule component by ID."
       description: >-
         **Note**:
 
-        
+
         Updating a rule component will also update the parent rule's `updated_at` timestamp.
 
 
@@ -7878,29 +8662,29 @@ paths:
         The following attributes can be updated for an existing rule component:
 
         * `delay_next`
-        
-        
+
+
         * `delegate_descriptor_id`
-        
-        
+
+
         * `extension_id`
-        
-        
+
+
         * `name`
-        
-        
+
+
         * `negate`
-        
-        
+
+
         * `order`
-        
-        
+
+
         * `rule_order`
-        
-        
+
+
         * `settings`
-        
-        
+
+
         * `timeout`
       parameters:
         - name: RULE_COMPONENT_ID
@@ -7925,6 +8709,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the new revision for the rule component.
           schema:
@@ -7993,9 +8781,13 @@ paths:
                 "meta":
                   "latest_revision_number": 0
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."  
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
     delete:
       tags:
         - Rule components
@@ -8012,12 +8804,20 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         204:
           description: A successful response returns HTTP status 204 (No Content).
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."   
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
   '/rule_components/{RULE_COMPONENT_ID}/extension':
     get:
       tags:
@@ -8039,6 +8839,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the extension that provides the rule component.
           schema:
@@ -8104,9 +8908,13 @@ paths:
                 "meta":
                   "latest_revision_number": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred." 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
   '/rule_components/{RULE_COMPONENT_ID}/origin':
     get:
       tags:
@@ -8128,6 +8936,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the rule component's origin.
           schema:
@@ -8196,9 +9008,13 @@ paths:
                 "meta":
                   "latest_revision_number": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred."  
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
   '/rule_components/{RULE_COMPONENT_ID}/rules':
     get:
       tags:
@@ -8220,6 +9036,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of related rules attached the rule component.
           schema:
@@ -8271,9 +9091,13 @@ paths:
                   "meta":
                     "latest_revision_number": 0
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
-          description: "An internal server error has ocurred." 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: "An internal server error has ocurred."
   '/notes/{NOTE_ID}':
     get:
       tags:
@@ -8292,6 +9116,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the note.
           schema:
@@ -8315,8 +9143,12 @@ paths:
                   "resource": "https://reactor.adobe.io/properties/PR4537ac6f1f204ffd864ec47c4b27c2e8"
                   "self": "https://reactor.adobe.io/notes/NT550b7a17ab304d49ba289a2978d673e5"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/properties/{PROPERTY_ID}/notes':
     get:
@@ -8340,6 +9172,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of notes belonging to the specified property.
           schema:
@@ -8370,8 +9206,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -8400,6 +9240,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the newly created note.
           schema:
@@ -8423,8 +9267,12 @@ paths:
                   "resource": "https://reactor.adobe.io/properties/PR4537ac6f1f204ffd864ec47c4b27c2e8"
                   "self": "https://reactor.adobe.io/notes/NT550b7a17ab304d49ba289a2978d673e5"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/data_elements/{DATA_ELEMENT_ID}/notes':
     get:
@@ -8444,6 +9292,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of notes belonging to the specified data element.
           schema:
@@ -8473,9 +9325,13 @@ paths:
                   "prev_page": null
                   "total_pages": 1
                   "total_count": 1
-        400:  
+        400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -8504,6 +9360,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the newly created note.
           schema:
@@ -8527,8 +9387,12 @@ paths:
                   "resource": "https://reactor.adobe.io/properties/PR4537ac6f1f204ffd864ec47c4b27c2e8"
                   "self": "https://reactor.adobe.io/notes/NT550b7a17ab304d49ba289a2978d673e5"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/extensions/{EXTENSION_ID}/notes':
     get:
@@ -8549,6 +9413,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of notes that are attached to the specified extension.
           schema:
@@ -8579,8 +9447,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -8609,6 +9481,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the newly created note.
           schema:
@@ -8632,8 +9508,12 @@ paths:
                   "resource": "https://reactor.adobe.io/extensions/EX585c96824669496b8de14706e617fd0a"
                   "self": "https://reactor.adobe.io/notes/NTe8876c73d5124fb79cb39985f7c04a98"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/libraries/{LIBRARY_ID}/notes':
     get:
@@ -8657,6 +9537,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of notes attached the library.
           schema:
@@ -8687,8 +9571,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -8717,6 +9605,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the newly created note.
           schema:
@@ -8740,8 +9632,12 @@ paths:
                   "resource": "https://reactor.adobe.io/libraries/LB76ad8640b51e43899f6e2175b7a22022"
                   "self": "https://reactor.adobe.io/notes/NTf4895245b3f54c3f8f9cdf1efe88baae"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rules/{RULE_ID}/notes':
     get:
@@ -8765,6 +9661,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of notes attached the rule.
           schema:
@@ -8795,8 +9695,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -8825,6 +9729,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the newly created note.
           schema:
@@ -8848,8 +9756,12 @@ paths:
                   "resource": "https://reactor.adobe.io/rules/RL6c7e8c1a07e442c8ad83347dd07bb11c"
                   "self": "https://reactor.adobe.io/notes/NT26a79c1d7cfa4bbc9175d05b578af8aa"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/rule_components/{RULE_COMPONENT_ID}/notes':
     get:
@@ -8873,6 +9785,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns a list of notes attached the rule component.
           schema:
@@ -8903,8 +9819,12 @@ paths:
                   "total_pages": 1
                   "total_count": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
     post:
       tags:
@@ -8933,6 +9853,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the newly created note.
           schema:
@@ -8956,8 +9880,12 @@ paths:
                   "resource": "https://reactor.adobe.io/rule_components/RC7320d11d52ed4c38972e44f7ca2d30cc"
                   "self": "https://reactor.adobe.io/notes/NT8415f74c21104d30ab0e75e5ae167351"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/audit_events':
     get:
@@ -8975,6 +9903,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns an array of audit events, including their IDs and attributes.
           schema:
@@ -9042,8 +9974,12 @@ paths:
                   "total_pages": 1
                   "total_count": 2
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/audit_events/{EVENT_ID}':
     get:
@@ -9063,6 +9999,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the audit event.
           schema:
@@ -9098,8 +10038,12 @@ paths:
                 "meta":
                   "property_name": "Kessel Example Property"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/profile':
     get:
@@ -9114,6 +10058,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the details of the profile.
           schema:
@@ -9174,8 +10122,12 @@ paths:
                   "rights":
                     - "manage_companies"
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
   '/search':
     post:
@@ -9201,6 +10153,10 @@ paths:
       produces:
       - application/vnd.api+json;revision=1
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A successful response returns the results of the search query.
           schema:
@@ -9263,9 +10219,41 @@ paths:
               "meta":
                 "total_hits": 1
         401:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "Access is unauthorized."
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: "An internal server error has ocurred."
+definitions:
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
 parameters:
   authorization:
     name: Authorization

--- a/acpdr/swagger-specs/real-time-customer-profile.yaml
+++ b/acpdr/swagger-specs/real-time-customer-profile.yaml
@@ -19,7 +19,7 @@ info:
       - PLATFORM Gateway URL: https://<span>platform.adobe.io/
       - Base path for this API: /data/core/ups
       - Example of a complete path: https://<span>platform.adobe.io/data/core/ups/config/mergePolicies
-      
+
     - Required headers:
       - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
       - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
@@ -58,24 +58,31 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name' 
+        - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Returns a list of computed attributes
           schema:
             $ref: '#/definitions/listComputedAttributes'
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
     post:
       tags:
         - (Alpha) Computed Attributes
       summary: Create a computed attribute.
-      description: >- 
-        **Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.**  
-        
-        
+      description: >-
+        **Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.**
+
+
         In order to configure a computed attribute, you first need to identify the field that will hold the computed attribute value. This field can be created using a mixin to add a new field to an existing schema, or by selecting a field that you have already defined within a schema.
 
 
@@ -93,27 +100,35 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/createComputedAttribute'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Returns the details of the newly created computed attribute
           schema:
             $ref: '#/definitions/computedAttributeResponse'
         '400':
-          description: >- 
+
+          description: >-
             Bad Request. Common examples include:
               * "Function with the same name already exists for the specified schema or definedOn"
               * "Could not lookup schema of the computed attribute for the provided path"
               * "Return schema of the expression is not same as the schema of the computed attribute in the XDM schema".
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
   '/config/computedAttributes/{ATTRIBUTE_ID}':
     get:
       tags:
         - (Alpha) Computed Attributes
       summary: Retrieve a specific computed attribute by its ID.
-      description: >- 
-        **Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.** 
+      description: >-
+        **Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.**
       operationId: lookupComputedAttribute
       produces:
         - application/json
@@ -122,24 +137,32 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name' 
+        - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Returns the details of the computed attribute
           schema:
             $ref: '#/definitions/computedAttributeResponse'
         '404':
+
           description: Computed attribute not found
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
     patch:
       tags:
         - (Alpha) Computed Attributes
       summary: Update a computed attribute by its ID.
-      description: >- 
-        **Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.** 
+      description: >-
+        **Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.**
       operationId: updateComputedAttribute
       produces:
         - application/json
@@ -148,23 +171,31 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name' 
+        - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/computedAttributeUpdate'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '204':
           description: Returns HTTP Status 204 (No Content) and an empty response body
         '404':
+
           description: Computed attribute not found
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
     delete:
       tags:
         - (Alpha) Computed Attributes
       summary: Delete a computed attribute by its ID.
-      description: >- 
-        **Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.** 
+      description: >-
+        **Warning: Computed attributes functionality is currently in alpha and is not available to all users. Functionality is subject to change.**
       operationId: deleteComputedAttribute
       produces:
         - application/json
@@ -173,17 +204,26 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name' 
+        - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Returns HTTP Status 200 (OK) and an empty response body
         '404':
+
           description: Computed attribute not found
         '422':
+
           description: Cannot perform delete as some other functions are dependent on this function.
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
   '/config/mergePolicies':
     get:
@@ -198,7 +238,7 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'      
+        - $ref: '#/parameters/x-sandbox-name'
         - name: x-request-id
           in: header
           description: Request Id
@@ -236,13 +276,20 @@ paths:
           type: boolean
           x-example: true
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: List of merge policies returned
           schema:
             $ref: '#/definitions/MergePoliciesResponse'
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
     post:
       tags:
@@ -257,7 +304,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'           
+        - $ref: '#/parameters/content-type'
         - name: x-profile-instance-id
           in: header
           description: Profile Instance ID
@@ -277,19 +324,28 @@ paths:
           schema:
             $ref: '#/definitions/PostMergePolicy'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Merge Policy successfully created
           schema:
             $ref: '#/definitions/MergePolicy'
         '400':
+
           description: Please double check your post body
         '403':
+
           description: Forbidden
         '429':
           description: Request rate too large!
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
   '/config/mergePolicies/{mergePolicyId}':
     get:
@@ -313,15 +369,23 @@ paths:
           type: string
           x-example: q0gf6caRuRtX2s5khaN1Zgd1OoEXcPJA
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: MergePolicy successfully returned
           schema:
             $ref: '#/definitions/MergePolicy'
         '403':
+
           description: Forbidden
         '404':
+
           description: MergePolicy not found
         '503':
+
           description: Service Unavailable
     put:
       tags:
@@ -356,19 +420,28 @@ paths:
           schema:
             $ref: '#/definitions/MergePolicy'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Merge Policy successfully updated
           schema:
             $ref: '#/definitions/MergePolicy'
         '400':
+
           description: Please double check your post body
         '403':
+
           description: Forbidden
         '429':
           description: Request rate too large!
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
     patch:
       tags:
@@ -405,17 +478,26 @@ paths:
           items:
             $ref: '#/definitions/PatchOperation'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Merge Policy successfully updated
         '400':
+
           description: Please double check your post body
         '403':
+
           description: Forbidden
         '429':
           description: Request rate too large!
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
     delete:
       tags:
@@ -438,13 +520,21 @@ paths:
           type: string
           x-example: q0gf6caRuRtX2s5khaN1Zgd1OoEXcPJA
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Merge Policy deleted successfully
         '403':
+
           description: Forbidden
         '404':
+
           description: MergePolicy not found
         '503':
+
           description: Service Unavailable
   '/config/mergePolicies/bulk-get':
     post:
@@ -470,10 +560,15 @@ paths:
                 type: array
                 items:
                   type: object
-                example: 
+                example:
                   - id: 10648288-cda5-11e8-a8d5-f2801f1b9fd1
                   - id: 42d4a596-b1c6-46c0-994e-ca5ef1f85130
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '207':
           description: The details of each merge policy are returned. The sample response has been truncated to show only the details for the first merge policy.
           schema:
@@ -483,7 +578,7 @@ paths:
                 type: object
                 properties:
                   "{MERGE_POLICY_ID}":
-                    $ref: '#/definitions/MergePolicy'      
+                    $ref: '#/definitions/MergePolicy'
   '/access/entities':
     get:
       tags:
@@ -569,9 +664,9 @@ paths:
           required: false
           type: string
         - name: property
-          description: >- 
+          description: >-
             Filter by the property value. Supported evaluators include =, !=, <, <=, >, >=. If more than one property filter is provided, it needs to be concatenated with `&`. Only a maximum of **three** properties are supported. When using URLs, they must be encoded. When using date filters, they must be encoded as a string in the format "yyyy-mm-dd" or "yyyymmdd". This query parameter is only supported for experience events.<br><br>Example: `property=web.webPageDetails.isHomepage=false&property=placeContext.localTime<="2020-07-20"`
-          x-example: 'property=web.webPageDetails.isHomepage=false&property=placeContext.localTime<="2020-07-20"' 
+          x-example: 'property=web.webPageDetails.isHomepage=false&property=placeContext.localTime<="2020-07-20"'
           in: query
           type: string
         - name: withCA
@@ -581,23 +676,31 @@ paths:
           required: false
           type: boolean
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: XDM object(s) successfully returned.
           schema:
             $ref: '#/definitions/GetXDMObjectResponseEntity'
         '400':
+
           description: Bad Request.
           schema:
             $ref: '#/definitions/ResponseErrorContext'
         '422':
+
           description: Syntax is correct but Profile Access is not able to process your request.
           schema:
             $ref: '#/definitions/ResponseErrorContext'
         '403':
+
           description: Forbidden.
           schema:
             $ref: '#/definitions/ForbiddenError'
         '404':
+
           description: XDM objects not found.
           schema:
             $ref: '#/definitions/NotFoundError'
@@ -608,6 +711,7 @@ paths:
             items:
               $ref: '#/definitions/TooManyRequestError'
         '500':
+
           description: Internal Server Error.
           schema:
             $ref: '#/definitions/ResponseInternalErrorContext'
@@ -624,7 +728,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'        
+        - $ref: '#/parameters/content-type'
         - in: body
           name: body
           description: XDM objects to be created. Each object should be in JSON format.
@@ -632,6 +736,11 @@ paths:
           schema:
             $ref: '#/definitions/PostRequestBodyEntity'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: XDM objects successfully returned.
           schema:
@@ -643,14 +752,17 @@ paths:
             items:
               $ref: '#/definitions/ErrorResponseById'
         '400':
+
           description: Bad Request.
           schema:
             $ref: '#/definitions/ResponseErrorContext'
         '403':
+
           description: Forbidden.
           schema:
             $ref: '#/definitions/ForbiddenError'
         '404':
+
           description: XDM objects not found
           schema:
             $ref: '#/definitions/NotFoundError'
@@ -661,6 +773,7 @@ paths:
             items:
               $ref: '#/definitions/TooManyRequestError'
         '500':
+
           description: Internal Server Error.
           schema:
             $ref: '#/definitions/ResponseInternalErrorContext'
@@ -700,6 +813,11 @@ paths:
           type: string
           x-example: '963d71a1-9875-4aea-a52b-c5c7a2504cae'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '202':
           description: Accepted
         '207':
@@ -709,14 +827,17 @@ paths:
             items:
               $ref: '#/definitions/ErrorResponseById'
         '400':
+
           description: BadRequest
           schema:
             $ref: '#/definitions/ResponseErrorContext'
         '403':
+
           description: Forbidden
           schema:
             $ref: '#/definitions/ForbiddenError'
         '404':
+
           description: Not Found
           schema:
             $ref: '#/definitions/NotFoundError'
@@ -727,9 +848,10 @@ paths:
             items:
               $ref: '#/definitions/TooManyRequestError'
         '500':
+
           description: Internal Server Error.
           schema:
-            $ref: '#/definitions/ResponseInternalErrorContext'                  
+            $ref: '#/definitions/ResponseInternalErrorContext'
   '/config/projections':
     get:
       tags:
@@ -740,10 +862,10 @@ paths:
       produces:
         - application/vnd.adobe.platform.projectionConfigList+json; version=1
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/x-api-key'      
+        - $ref: '#/parameters/x-api-key'
         - name: x-gw-ims-authorization
           in: header
           description: Gateway IMS service token.
@@ -775,19 +897,27 @@ paths:
           type: string
           x-example: d41ee840-0a10-4393-ab55-12fa54cb6172
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: The edge projection configuration is returned.
           schema:
             $ref: '#/definitions/ProjectionConfigurationList'
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -796,20 +926,26 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
     post:
       tags:
@@ -822,10 +958,10 @@ paths:
       produces:
         - application/vnd.adobe.platform.projectionConfig+json; version=1
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/x-api-key'  
+        - $ref: '#/parameters/x-api-key'
         - name: schemaName
           in: query
           description: XDM schema name
@@ -858,19 +994,27 @@ paths:
           type: string
           x-example: d41ee840-0a10-4393-ab55-12fa54cb6172
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '201':
           description: Creation was successful.
           schema:
             $ref: '#/definitions/ProjectionConfig'
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -879,6 +1023,7 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -887,16 +1032,21 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
   '/config/projections/{projectionid}':
     get:
@@ -908,7 +1058,7 @@ paths:
       produces:
         - application/vnd.adobe.platform.projectionConfig+json; version=1
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/x-api-key'
@@ -936,23 +1086,32 @@ paths:
           type: string
           x-example: d41ee840-0a10-4393-ab55-12fa54cb6172
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: The edge projection configuration is returned.
           schema:
             $ref: '#/definitions/ProjectionConfig'
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '404':
+
           description: The edge projection configuration has not yet been created.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -961,20 +1120,26 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
     put:
       tags:
@@ -987,10 +1152,10 @@ paths:
       produces:
         - application/vnd.adobe.platform.projectionConfig+json; version=1
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/x-api-key'      
+        - $ref: '#/parameters/x-api-key'
         - name: projectionid
           in: path
           required: true
@@ -1006,7 +1171,7 @@ paths:
           name: body
           required: false
           schema:
-            $ref: '#/definitions/InputProjectionConfig'          
+            $ref: '#/definitions/InputProjectionConfig'
         - name: x-user-token
           in: header
           description: User access token.
@@ -1020,23 +1185,32 @@ paths:
           type: string
           x-example: d41ee840-0a10-4393-ab55-12fa54cb6172
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Update was successful.
           schema:
             $ref: '#/definitions/ProjectionConfig'
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '404':
+
           description: Projection config not found.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -1045,20 +1219,26 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
     delete:
       tags:
@@ -1067,10 +1247,10 @@ paths:
       description: 'API response is immediate, but the actual changes to the projections on the edges take place asynchronously. Eventually, the result is that the profile data for the given customer will be wiped from all edges.'
       operationId: deleteProjectionConfiguration
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/x-api-key'      
+        - $ref: '#/parameters/x-api-key'
         - name: projectionid
           in: path
           required: true
@@ -1095,21 +1275,30 @@ paths:
           type: string
           x-example: d41ee840-0a10-4393-ab55-12fa54cb6172
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '204':
           description: The edge projection configuration is successfully deleted.
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '404':
+
           description: The edge projection configuration has not yet been created.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -1118,20 +1307,26 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
   '/config/destinations':
     get:
@@ -1142,29 +1337,38 @@ paths:
       produces:
         - application/vnd.adobe.platform.projectionDestinationList+json; version=1
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/x-api-key' 
+        - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-request-id'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: The projection destination is returned.
           schema:
             $ref: '#/definitions/ProjectionDestinationRepresentation'
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '404':
+
           description: The projection destination has not yet been created.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -1173,20 +1377,26 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
     post:
       tags:
@@ -1199,10 +1409,10 @@ paths:
       produces:
         - application/vnd.adobe.platform.projectionDestination+json; version=1
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/x-api-key' 
+        - $ref: '#/parameters/x-api-key'
         - name: x-gw-ims-authorization
           in: header
           description: Gateway IMS service token.
@@ -1215,7 +1425,7 @@ paths:
           schema:
             $ref: '#/definitions/InputProjectionDestination'
           x-examples:
-            type: EDGE          
+            type: EDGE
         - name: x-user-token
           in: header
           description: User access token.
@@ -1229,19 +1439,27 @@ paths:
           type: string
           x-example: d41ee840-0a10-4393-ab55-12fa54cb6172
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '201':
           description: Creation was successful.
           schema:
             $ref: '#/definitions/ProjectionDestinationRepresentation'
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -1250,6 +1468,7 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -1258,16 +1477,21 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
   '/config/destinations/{destinationId}':
     get:
@@ -1279,10 +1503,10 @@ paths:
       produces:
         - application/vnd.adobe.platform.projectionDestination+json; version=1
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/x-api-key' 
+        - $ref: '#/parameters/x-api-key'
         - name: destinationId
           in: path
           required: true
@@ -1307,23 +1531,32 @@ paths:
           type: string
           x-example: d41ee840-0a10-4393-ab55-12fa54cb6172
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: The projection destination is returned.
           schema:
             $ref: '#/definitions/ProjectionDestinationRepresentation'
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '404':
+
           description: The projection destination has not yet been created.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -1332,20 +1565,26 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
     put:
       tags:
@@ -1358,10 +1597,10 @@ paths:
       produces:
         - application/vnd.adobe.platform.projectionDestination+json; version=1
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/x-api-key' 
+        - $ref: '#/parameters/x-api-key'
         - name: destinationId
           in: path
           required: true
@@ -1391,23 +1630,32 @@ paths:
           type: string
           x-example: d41ee840-0a10-4393-ab55-12fa54cb6172
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Update was successful.
           schema:
             $ref: '#/definitions/ProjectionDestinationRepresentation'
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '404':
+
           description: Projection destination not found.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -1416,20 +1664,26 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
     delete:
       tags:
@@ -1438,10 +1692,10 @@ paths:
       description: 'API response is immediate, but the actual changes to the projections on the edges take place asynchronously. Eventually, the result is that the profile data for the given customer will be wiped from all edges.'
       operationId: deleteProjectionDestination
       parameters:
-        - $ref: '#/parameters/authorization'        
+        - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/x-api-key' 
+        - $ref: '#/parameters/x-api-key'
         - name: destinationId
           in: path
           required: true
@@ -1466,21 +1720,30 @@ paths:
           type: string
           x-example: d41ee840-0a10-4393-ab55-12fa54cb6172
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '204':
           description: The edge projection destination is successfully deleted.
         '400':
+
           description: The request is malformed.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '401':
+
           description: The request has not been applied because it lacks valid authentication credentials for the target resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '403':
+
           description: The requester is not authorized to access the resource.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '404':
+
           description: The edge projection destination has not yet been created.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -1489,6 +1752,7 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '406':
+
           description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
           schema:
             $ref: '#/definitions/ProblemDetail'
@@ -1497,16 +1761,21 @@ paths:
           schema:
             $ref: '#/definitions/ProblemDetail'
         '422':
+
           description: Client sent a correct request that contained invalid values for one or more parameters.
           schema:
             $ref: '#/definitions/ProblemDetail'
         '500':
+
           description: This is an indicator of a server-side error.
         '502':
+
           description: This is an indicator that the back-end service did not send a valid response.
         '503':
+
           description: This is an indicator of a potential server overload.
         '504':
+
           description: This is an indicator that the back-end service did not complete a response within an allowed time period.
   '/system/jobs':
     get:
@@ -1521,7 +1790,7 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name' 
+        - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/start'
         - $ref: '#/parameters/limit'
         - name: page
@@ -1535,15 +1804,23 @@ paths:
           required: false
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Returns a list of all delete requests (Profile System Jobs) defined by your organization.
           schema:
             "$ref": "#/definitions/ProfileSystemJobsResponse"
         '403':
+
           description: Forbidden
         '503':
+
           description: Service Unavailable
         '500':
+
           description: Internal Server Error
     post:
       tags:
@@ -1551,13 +1828,13 @@ paths:
       summary: Create a delete request (Profile System Job)
       description: >-
         Initiating a new delete request is done through a POST request to the `/systems/jobs` endpoint, where the ID of the dataset or batch to be deleted is provided in the body of the request.
-        
-          In order to delete a dataset, the dataset ID must be included in the body of the POST request. This action will delete ALL data for a given dataset. Experience Platform allows you to delete datasets based on both record and time series schemas.
-          
-          In order to delete a batch, the batch ID must be included in the body of the POST request. Please be advised that you cannot delete batches for datasets based on record schemas. Only batches for datasets based on time series schemas may be deleted. 
 
-          **Note:** The reason you cannot delete batches for datasets based on record schemas is because record type dataset batches overwrite previous records and therefore cannot be "undone" or deleted. The way to remove the impact of erroneous batches for datasets based on record schemas is to re-ingest the batch with the correct data and it will overwrite the incorrect records. 
-          
+          In order to delete a dataset, the dataset ID must be included in the body of the POST request. This action will delete ALL data for a given dataset. Experience Platform allows you to delete datasets based on both record and time series schemas.
+
+          In order to delete a batch, the batch ID must be included in the body of the POST request. Please be advised that you cannot delete batches for datasets based on record schemas. Only batches for datasets based on time series schemas may be deleted.
+
+          **Note:** The reason you cannot delete batches for datasets based on record schemas is because record type dataset batches overwrite previous records and therefore cannot be "undone" or deleted. The way to remove the impact of erroneous batches for datasets based on record schemas is to re-ingest the batch with the correct data and it will overwrite the incorrect records.
+
           For more information on record and time series behavior, please review the section on XDM data behaviors in the [XDM System overview](https://experienceleague.adobe.com/docs/experience-platform/xdm/home.html).
       operationId: createDeleteRequest
       produces:
@@ -1572,9 +1849,9 @@ paths:
           in: body
           description: >-
             A JSON object containing the ID of the dataset or batch to be deleted.
-            
+
             **Example for batch ID:**
-            
+
             <pre>{
               "batchId": "8d075b5a178e48389126b9289dcfd0ac"
             }</pre>
@@ -1582,19 +1859,29 @@ paths:
           schema:
               "$ref": "#/definitions/XdmDataJobPostBodyWithDataSetId"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Delete request (Profile System Job) successfully created
           schema:
             "$ref": "#/definitions/ProfileSystemJob"
         '400':
+
           description: Invalid delete request (Profile System Job)
         '403':
+
           description: Forbidden
         '422':
+
           description: Delete request (Profile System Job) Definition already exists.
         '503':
+
           description: Service Unavailable
         '500':
+
           description: Internal Server Error
   '/system/jobs/{ID}':
     get:
@@ -1616,17 +1903,26 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: Returns the details of a specific delete request (Profile System Job).
           schema:
             $ref: '#/definitions/ProfileSystemJob'
         '403':
+
           description: Forbidden
         '404':
+
           description: Delete request (Profile System Job) not found
         '500':
+
           description: Internal Server Error
         '503':
+
           description: Service Unavailable
     delete:
       tags:
@@ -1647,13 +1943,21 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: If removal is successful, returns HTTP Status 200 (OK) and an empty response body.
         '403':
+
           description: Forbidden
         '404':
+
           description: Delete request (Profile System Job) not found
         '503':
+
           description: Service Unavailable
   '/previewsamplestatus':
     get:
@@ -1668,15 +1972,22 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name' 
+        - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: "Returns the details of the last successful sample that was run for the IMS Org."
           schema:
             $ref: '#/definitions/PreviewSampleStatusPageResponse'
         '403':
+
           description: "Forbidden"
         '503':
+
           description: "Service Unavailable"
   '/previewsamplestatus/report/dataset':
     get:
@@ -1691,20 +2002,27 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name' 
+        - $ref: '#/parameters/x-sandbox-name'
         - name: "date"
           in: "query"
           description: "Specify the date of the report to be returned. If multiple reports were run on the date, the most recent report for that date will be returned. If a report does not exist for the specified date, a 404 error will be returned. If no date is specified, the most recent report will be returned. Format: YYYY-MM-DD. Example: date=2024-12-31"
           required: false
           type: "string"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: "Returns a report showing profile distribution by dataset for the IMS Org."
           schema:
             $ref: '#/definitions/DatasetReportResponse'
         '404':
+
           description: "Dataset report does not exist for this date."
         '503':
+
           description: "Service Unavailable"
   '/previewsamplestatus/report/namespace':
     get:
@@ -1719,22 +2037,29 @@ paths:
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name' 
+        - $ref: '#/parameters/x-sandbox-name'
         - name: "date"
           in: "query"
           description: "Specify the date of the report to be returned. If multiple reports were run on the date, the most recent report for that date will be returned. If a report does not exist for the specified date, a 404 error will be returned. If no date is specified, the most recent report will be returned. Format: YYYY-MM-DD. Example: date=2024-12-31"
           required: false
           type: "string"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
         '200':
           description: "Returns a report showing profile distribution by namespace for the IMS Org."
           schema:
             $ref: '#/definitions/NamespaceReportResponse'
         '404':
+
           description: "Namespace report does not exist for this date."
         '503':
+
           description: "Service Unavailable"
-definitions:     
+definitions:
   listComputedAttributes:
     type: object
     properties:
@@ -1744,7 +2069,7 @@ definitions:
           totalCount:
             type: integer
             example: 1
-          pageSize: 
+          pageSize:
             type: integer
             example: 1
       children:
@@ -1804,16 +2129,16 @@ definitions:
       sandbox:
         type: object
         properties:
-          sandboxId: 
+          sandboxId:
             type: string
             example: "ff0f6870-c46d-11e9-8ca3-036939a64204"
-          sandboxName: 
+          sandboxName:
             type: string
             example: "prod"
-          type: 
+          type:
             type: string
             example: "production"
-          default: 
+          default:
             type: boolean
             example: true
       name:
@@ -1855,41 +2180,41 @@ definitions:
           "meta:xdmType":
             type: string
             example: string
-      definedOn: 
+      definedOn:
         type: array
         items:
           type: object
           properties:
-            "meta:resourceType": 
+            "meta:resourceType":
               type: string
               example: "unions"
             "meta:containerId":
               type: string
               example: "tenant"
-            "$ref": 
+            "$ref":
               type: string
               example: "https://ns.adobe.com/xdm/context/profile__union"
       encodedDefinedOn:
         type: string
         example: "?\b?VR)JMS?R?())(????+?KL?OJ?K???H??O??+I?(?/(?O??I??/????S?8{?E:"
-      dependencies: 
+      dependencies:
         type: array
         items:
           type: string
-      dependents: 
+      dependents:
         type: array
         items:
           type: string
-      active: 
+      active:
         type: boolean
         example: true
-      type: 
+      type:
         type: string
         example: "ComputedAttribute"
-      createEpoch: 
+      createEpoch:
         type: integer
         example: 1572555223
-      updateEpoch: 
+      updateEpoch:
         type: integer
         example: 1572555225
   updateComputedAttribute:
@@ -2199,7 +2524,7 @@ definitions:
         properties:
           name:
             type: string
-            example: '_xdm.context.profile'  
+            example: '_xdm.context.profile'
       fields:
         description: 'Fields for the model object. By default, all fields will be fetched. Separated by comma.'
         type: array
@@ -2398,7 +2723,7 @@ definitions:
       dataSetId:
         type: string
         example: "5cf212ed73fbff145365d15d"
-        description: dataSetId      
+        description: dataSetId
   ProfileSystemJob:
     type: object
     properties:
@@ -2610,11 +2935,38 @@ definitions:
         type: "string"
         description: "The timestamp of the report. If a `date` parameter was provided during the request, the report returned is for the date provided. If no `date` parameter is provided, the most recent report is returned."
         example: "2020-08-01T17:57:58.697"
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
 parameters:
   authorization:
     name: Authorization
-    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ". 
-    For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
+    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ".
+      For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
     required: true
     type: string
     in: header
@@ -2641,15 +2993,15 @@ parameters:
     name: body
     description: >-
       A JSON object containing the details of the computed attribute being created.
-      
+
       * **name: (Required)** The name of the computed attribute field, as a string.
-      
+
       * **path: (Required)** The path to the computed attributed field within a schema. This path is found within the 'properties' attribute of the schema, but it omits the layers of 'properties' when writing the path. It also omits the field name itself. For example, if the computed attribute path is a.b.c, the "name" is "c" and the "path" is "a.b".
         * **{TENANT_ID}:** If you are unfamiliar with your tenant ID, please refer to the steps for finding your tenant ID in the [Schema Registry developer guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/getting-started.html?lang=en#know-your-tenant_id)
       * **description:** *(Optional)* A description of the computed attribute. This is especially useful once multiple computed attributes have been defined as it will help others within your IMS Organization to determine the correct computed attribute to use.
-      
+
       * **expression: (Required)** A valid Profile Query Language (PQL) expression. For more information on PQL and links to supported queries, please read the [PQL overview documentation](https://experienceleague.adobe.com/docs/experience-platform/segmentation/pql/overview.html).
-      
+
       * **schema.name: (Required)** The class upon which the schema containing the computed attribute field is based. For example, if the schema was based on the XDM ExperienceEvent class, the value would be '_xdm.context.experienceevent'.
     required: true
     schema:
@@ -2664,8 +3016,8 @@ parameters:
     name: body
     description: >-
       Use [JSON Patch formatting](http://jsonpatch.com/) to update the computed attribute.
-      
-      
+
+
       The "value" must be a valid Profile Query Language (PQL) expression. For more information on PQL and links to supported queries, please read the [PQL overview documentation](https://experienceleague.adobe.com/docs/experience-platform/segmentation/pql/overview.html).
     required: true
     in: body
@@ -2689,7 +3041,7 @@ parameters:
     description: All resources in Experience Platform are isolated to specific virtual sandboxes. Requests to Platform APIs require a header that specifies the name of the sandbox in which the operation will take place. See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
     required: true
     type: string
-  x-profile-instance-id:  
+  x-profile-instance-id:
     name: x-profile-instance-id
     in: header
     description: Profile instance ID.
@@ -2709,13 +3061,13 @@ parameters:
     description: Macro ID. For example, `ca8fe8a8-0f38-478a-9905-fd515d1d2988`
     required: true
     type: string
-  start:      
+  start:
     name: start
     in: query
     description: Return results from a specific page offset. For example, `start=3`
     required: false
     type: integer
-  limit:  
+  limit:
     name: limit
     in: query
     description: Limit response to a specific number of objects. Must be a positive number. For example, `limit=10`

--- a/acpdr/swagger-specs/sandbox-api.yaml
+++ b/acpdr/swagger-specs/sandbox-api.yaml
@@ -16,14 +16,14 @@ info:
 
     - API paths:
         - PLATFORM Gateway URL: https://<span>platform.adobe.io/
-        - Base path for this API: /data/foundation/sandbox-management
+        - Base path for this API: /data/foundation
         - Example of a complete path: https://<span>platform.adobe.io/data/foundation/sandbox-management/sandboxes
 
     - Required headers:
         - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
         - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
         - All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.
-basePath: /data/foundation/sandbox-management/
+basePath: /data/foundation
 host: platform.adobe.io
 tags:
   - name: Admin operations
@@ -31,7 +31,7 @@ tags:
   - name: User operations
     description: Sandbox operations available to all users.
 paths:
-  /:
+  /sandbox-management/:
     get:
       tags:
         - User operations
@@ -58,7 +58,7 @@ paths:
           description: Not found
         500:
           description: Internal server error
-  /sandboxTypes:
+  /sandbox-management/sandboxTypes:
     get:
       tags:
         - Admin operations
@@ -84,7 +84,7 @@ paths:
           description: Not found
         500:
           description: Internal server error
-  /sandboxes:
+  /sandbox-management/sandboxes:
     get:
       tags:
         - Admin operations
@@ -145,7 +145,7 @@ paths:
           description: Conflict
         500:
           description: Internal server error
-  /sandboxes/{sandboxName}:
+  /sandbox-management/sandboxes/{sandboxName}:
     get:
       tags:
         - Admin operations

--- a/acpdr/swagger-specs/sandbox-api.yaml
+++ b/acpdr/swagger-specs/sandbox-api.yaml
@@ -23,7 +23,7 @@ info:
         - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
         - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
         - All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.
-basePath: /data/foundation/sandbox-management
+basePath: /data/foundation/sandbox-management/
 host: platform.adobe.io
 tags:
   - name: Admin operations

--- a/acpdr/swagger-specs/sandbox-api.yaml
+++ b/acpdr/swagger-specs/sandbox-api.yaml
@@ -46,17 +46,29 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/x-user-token'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: A list of sandboxes with matching criteria.
           schema:
             $ref: '#/definitions/GetSandboxesUserResponse'
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad request
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal server error
   /sandbox-management/sandboxTypes:
     get:
@@ -72,17 +84,29 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: List of supported sandbox types
           schema:
             $ref: '#/definitions/ListSandboxTypesResponse'
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad request
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal server error
   /sandbox-management/sandboxes:
     get:
@@ -103,17 +127,29 @@ paths:
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/orderBy'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: OK
           schema:
             $ref: "#/definitions/GetSandboxesSystemResponse"
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad request
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal server error
     post:
       tags:
@@ -133,17 +169,27 @@ paths:
         - $ref: '#/parameters/x-user-token'
         - $ref: '#/parameters/sandboxPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: Request accepted
           schema:
             $ref: '#/definitions/CreateSandboxResponse'
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad request
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         409:
           description: Conflict
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal server error
   /sandbox-management/sandboxes/{sandboxName}:
     get:
@@ -163,17 +209,29 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/x-user-token'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: OK
           schema:
             $ref: '#/definitions/GetSandboxResponse'
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad request
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal server error
     delete:
       tags:
@@ -192,6 +250,10 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/x-user-token'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: request accepted
           schema:
@@ -201,12 +263,20 @@ paths:
               description: Url to check status of the request
               type: string
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad request
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal server error
     put:
       tags:
@@ -232,6 +302,10 @@ paths:
           schema:
             $ref: '#/definitions/ResetSandboxPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         202:
           description: Request accepted
           headers:
@@ -239,12 +313,20 @@ paths:
               description: URL to check status of the request
               type: string
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad request
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal server error
     patch:
       tags:
@@ -270,17 +352,29 @@ paths:
           schema:
             $ref: '#/definitions/PatchSandboxPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: OK
           schema:
             $ref: '#/definitions/GetSandboxResponse'
         400:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad request
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not found
         500:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal server error
 
 parameters:
@@ -664,3 +758,30 @@ definitions:
       region:
         type: string
         example: VA7
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true

--- a/acpdr/swagger-specs/sandbox-api.yaml
+++ b/acpdr/swagger-specs/sandbox-api.yaml
@@ -5,7 +5,7 @@ info:
   description: >-
     - Service description:
         - Adobe Experience Platform provides virtual sandbox environments which provide isolation and access control for Platform integrations. Sandboxes can be used for application lifecycle management, project management, and building customized development ecosystems.
-    
+
     - Related documentation:
         - [Sandbox documentation](https://adobe.com/go/sandbox-overview-en)
 
@@ -13,17 +13,18 @@ info:
         - [Sandbox API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Sandbox%20API.postman_collection.json)
         - [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)
         - [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)
-    
+
     - API paths:
         - PLATFORM Gateway URL: https://<span>platform.adobe.io/
         - Base path for this API: /data/foundation/sandbox-management
         - Example of a complete path: https://<span>platform.adobe.io/data/foundation/sandbox-management/sandboxes
-    
+
     - Required headers:
         - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
         - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
         - All requests with a payload in the request body (such as POST, PUT, and PATCH calls) must include the header `Content-Type` with a value of `application/json`.
-    
+basePath: /data/foundation/sandbox-management
+host: platform.adobe.io
 tags:
   - name: Admin operations
     description: Sandbox operations available only to admins. Sandbox admin privileges are managed through the [Adobe Admin Console](https://adminconsole.adobe.com).

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -2,24 +2,24 @@ swagger: '2.0'
 info:
   version: '1.0'
   title: Schema Registry API
-  description: >- 
+  description: >-
     * Service description:
       * The Schema Registry API is used to access the Schema Library within Adobe Experience Platform. The registry provides a user interface and RESTful API from which all available library resources are accessible.
-  
-  
+
+
     * Related documentation:
       * [XDM documentation](http://www.adobe.com/go/xdm-home-en)
-    
+
     * Visualize API calls with Postman (a free, third-party software):
       * [Schema Registry API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Schema%20Registry%20API.postman_collection.json)
       * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)
       * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)
-  
+
     * API paths:
       * PLATFORM Gateway URL: https://<span>platform.adobe.io
       * Base path for this API: /data/foundation/schemaregistry
       * Example of a complete path for making a call to "/stats": https://<span>platform.adobe.io/data/foundation/schemaregistry/stats
-    
+
     * Required headers:
       * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
       * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
@@ -75,7 +75,7 @@ paths:
       responses:
         '200':
           description: A successful response returns your tenant ID and Schema Registry usage information.
-          schema: 
+          schema:
             '$ref': '#/definitions/statsResponse'
         '400':
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
@@ -154,7 +154,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'        
+        - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/fieldGroupPayload'
       responses:
         '201':
@@ -203,8 +203,8 @@ paths:
       summary: Update one or more attributes of a custom field group by ID.
       description: >-
         The Schema Registry supports all standard JSON Patch operations, including add, remove, and replace, to allow you to modify or update resources you have defined.
-        
-        
+
+
         For more information on JSON Patch, including all available operations, read [the official JSON Patch documentation](http://jsonpatch.com).
       operationId: updateFieldGroup
       consumes:
@@ -238,8 +238,8 @@ paths:
       summary: Delete a custom field group by ID.
       description: >-
         Remove an existing field group through a DELETE request to the `$id` of the field group being removed.
-        
-        
+
+
         A successful deletion returns an empty response body and HTTP status 204 (No Content).
       operationId: removeFieldGroup
       parameters:
@@ -266,8 +266,8 @@ paths:
       summary: Retrieve a list of schemas within the specified container.
       description: >-
         You are able to view a list of all schemas within a container by performing a single GET request. To help filter results, the Schema Registry supports the use of query parameters when listing resources.
-        
-        
+
+
         The response format depends on the `Accept` header sent in the request. The following `Accept` headers are available for this request:<ul><li>`application/vnd.adobe.xed-id+json`: Returns a short summary of each resource, generally the preferred header for listing.</li><li>`application/vnd.adobe.xed+json`: Returns full JSON for each resource, with the original `$ref` and `allOf` attributes included.</li></ul>
       operationId: listAllSchemas
       produces:
@@ -307,8 +307,8 @@ paths:
       summary: Retrieve a schema within the specified container by ID.
       description: >-
         The response format depends on the `Accept` header sent in the request. The following `Accept` headers are available for this request:<ul><li>`application/vnd.adobe.xed+json; version=1`:  Raw with `$ref` and `allOf` included. Has titles and descriptions.</li><li>`application/vnd.adobe.xed-full+json; version=1`: `$ref` and `allOf` included. Has titles and descriptions.</li><li>`application/vnd.adobe.xed-notext+json; version=1`: Raw with `$ref` and `allOf` included, but with no titles or descriptions</li><li>`application/vnd.adobe.xed-full-notext+json; version=1`:  `$ref` and `allOf` are resolved, with no titles or descriptions.</li><li>`application/vnd.adobe.xed-full-desc+json; version=1`: `$ref` and `allOf` are resolved, with descriptions included.</li></ul>
-        
-        
+
+
         A lookup request requires the resource's major version be included in the `Accept` header. When supplying the major version, the registry returns the latest minor version automatically.
       operationId: lookupSchema
       produces:
@@ -346,7 +346,7 @@ paths:
       responses:
         '201':
           description: A successful response returns the details of the newly created schema.
-          schema: 
+          schema:
             '$ref': '#/definitions/createSchemaResponse'
         '400':
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
@@ -384,8 +384,8 @@ paths:
       summary: Update one or more attributes of a custom schema specified by ID.
       description: >-
         The Schema Registry supports all standard JSON Patch operations, including add, remove, and replace, to allow users to modify or update schemas they have defined.
-        
-        
+
+
         For more information on JSON Patch, including all available operations, read [the official JSON Patch documentation](http://jsonpatch.com).
       operationId: updateSchema
       consumes:
@@ -409,15 +409,15 @@ paths:
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
           description: An internal server error occurred.
-   
+
     delete:
       tags:
       - "Schemas"
       summary: Delete a custom schema by ID.
       description: >-
         Remove an existing schema by performing a DELETE request to the `$id` of the schema being removed.
-      
-      
+
+
         A successful deletion returns an empty response body and HTTP status 204 (No Content).
       operationId: removeSchema
       parameters:
@@ -626,7 +626,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'        
+        - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/fieldGroupPayload'
       responses:
         '201':
@@ -671,8 +671,8 @@ paths:
       deprecated: true
       description: >-
         The Schema Registry supports all standard JSON Patch operations, including add, remove, and replace, to allow users to modify or update mixins they have defined.
-        
-        
+
+
         For more information on JSON Patch, including all available operations, read [the official JSON Patch documentation](http://jsonpatch.com).
       operationId: updateMixin
       consumes:
@@ -701,8 +701,8 @@ paths:
       deprecated: true
       description: >-
         Remove an existing mixin through a DELETE request to the `$id` of the mixin being removed.
-        
-        
+
+
         A successful deletion returns an empty response body and HTTP status 204 (No Content).
       operationId: removeMixin
       parameters:
@@ -797,13 +797,13 @@ paths:
       responses:
         '201':
           description: A successful response returns the details of the newly created class.
-          schema: 
+          schema:
             '$ref': '#/definitions/createClassResponse'
         '400':
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
           description: An internal server error occurred.
-    
+
   '/tenant/classes/{CLASS_ID}':
     put:
       tags:
@@ -840,8 +840,8 @@ paths:
       summary: Update one or more attributes of a custom class specified by ID.
       description: >-
         The Schema Registry supports all standard JSON Patch operations, including add, remove, and replace, to allow users to modify or update classes they have defined.
-        
-        
+
+
         For more information on JSON Patch, including all available operations, read [the official JSON Patch documentation](http://jsonpatch.com).
       operationId: updateClass
       consumes:
@@ -873,8 +873,8 @@ paths:
       summary: Delete a custom class by ID.
       description: >-
         Remove a class by performing a DELETE request to the `$id` of the class being removed.
-        
-        
+
+
         A successful deletion returns an empty response body and HTTP status 204 (No Content).
       operationId: removeClass
       parameters:
@@ -967,7 +967,7 @@ paths:
       responses:
         '201':
           description: A successful response returns the details of the newly created data type.
-          schema: 
+          schema:
             '$ref': '#/definitions/createDataTypeResponse'
         '400':
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
@@ -995,7 +995,7 @@ paths:
       responses:
         '200':
           description: A successful response returns the details of the updated data type.
-          schema: 
+          schema:
             '$ref': '#/definitions/putDataTypeResponse'
         '400':
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
@@ -1006,10 +1006,10 @@ paths:
       - "Data types"
       summary: Update one or more attributes of a custom data type specified by ID.
       description: >-
-      
+
         The Schema Registry supports all standard JSON Patch operations, including add, remove, and replace, to allow users to modify or update data types they have defined.
-        
-        
+
+
         For more information on JSON Patch, including all available operations, read [the official JSON Patch documentation](http://jsonpatch.com).
       consumes:
         - application/json
@@ -1026,7 +1026,7 @@ paths:
       responses:
         '200':
           description: A successful response returns the details of the updated data type.
-          schema: 
+          schema:
             '$ref': '#/definitions/patchDataTypeResponse'
         '400':
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
@@ -1038,8 +1038,8 @@ paths:
       summary: Delete a custom class by ID.
       description: >-
         Removing a data type is done through a DELETE request to the `$id` of the data type being removed.
-        
-        
+
+
         A successful deletion returns an empty response body and HTTP status 204 (No Content).
       operationId: removeDatatype
       parameters:
@@ -1062,20 +1062,20 @@ paths:
       summary: Retrieve a list descriptors within the specified container, sorted by type.
       description: >-
         Schemas define a static view of data entities, but do not provide specific details on how data based on these schemas (datasets) may relate to one another. Adobe Experience Platform allows you to describe these relationships and other interpretive metadata about a schema through the use of descriptors.
-        
-        
+
+
         Descriptors are tenant-level metadata for schemas, meaning they are unique to your IMS Organization and all descriptor operations take place in the `tenant` container.
-        
-        
+
+
         Each schema can have one or more schema descriptor entities applied to it. Each schema descriptor entity includes a descriptor '@type' and the 'sourceSchema' to which it applies. Once applied, these descriptors will apply to all datasets created using the schema.
-        
-        
+
+
         In order to help filter returned data, the Schema Registry supports the use of query parameters when listing descriptors.
-        
-        
+
+
         `Accept` headers for descriptors include:
-        
-        
+
+
         <table><thead><tr><th>`Accept`</th><th>Description</th></tr></thead><tbody><tr><td>`application/vnd.adobe.xdm-id+json`</td><td>Returns a list of descriptor IDs, grouped by their `@type`.</td></tr><tr><td>`application/vnd.adobe.xdm-link+json`</td><td>Returns a list of descriptor API paths, grouped by their `@type`.</td></tr><tr><td>`application/vnd.adobe.xdm+json`</td><td>Returns a list of descriptor objects, grouped by their `@type`.</td></tr><tr><td>`application/vnd.adobe.xdm-v2{-id/-link}+json`</td><td>Including the `-v2` option in any of the above `Accept` headers permits paging functionality, returning a results array with a `_page` attribute that can be used to request the next page if needed.</td></tr></tbody></table>
       operationId: listAllDescriptors
       produces:
@@ -1166,17 +1166,17 @@ paths:
           description: Forbidden
         '500':
           description: An internal server error occurred.
-  
+
   '/tenant/descriptors/{DESCRIPTOR_ID}':
     put:
       tags:
       - "Descriptors"
       summary: Update a descriptor by ID.
       description: >-
-      
+
         Update a descriptor by issuing a PUT request to the `@id` of the descriptor being updated.
-        
-        
+
+
         This action is **re-writing** the existing descriptor, therefore the payload must include all descriptor fields that were required when the descriptor was defined.
       operationId: updateDescriptor
       consumes:
@@ -1669,16 +1669,16 @@ definitions:
         type: array
         description: Array of objects containing details of recently updated resources.
         items:
-          type: object   
+          type: object
       classUsage:
         type: object
         properties:
-          'https://ns.adobe.com/xdm/context/profile': 
+          'https://ns.adobe.com/xdm/context/profile':
             type: array
             items:
               type: object
               properties:
-                $id: 
+                $id:
                   type: string
                   example: 'https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18'
                 title:
@@ -1783,7 +1783,7 @@ definitions:
         example: false
       meta:extends:
         type: array
-        items: 
+        items:
           type: string
           example: https://ns.adobe.com/xdm/context/profile
       meta:containerId:
@@ -1795,7 +1795,7 @@ definitions:
       $id:
         type: string
         example: https://ns.adobe.com/{TENANT_ID}/schemas/fbc52b243d04b5d4f41eaa72a8ba58be
-      meta:altId: 
+      meta:altId:
         type: string
         example: "_{TENANT_ID}.schemas.fbc52b243d04b5d4f41eaa72a8ba58be"
       version:
@@ -1819,7 +1819,7 @@ definitions:
           xdm:createdClientId:
             type: string
             example: '{CREATED_CLIENT}'
-          xdm:repositoryCreatedBy: 
+          xdm:repositoryCreatedBy:
             type: string
             example: '{CREATED_BY}'
   lookupSchemaResponse:
@@ -1831,7 +1831,7 @@ definitions:
       title:
         type: string
         example: Tenant Data Schema
-      description: 
+      description:
         type: string
         example: Schema for tenant-specific data
       meta:extensible:
@@ -1857,7 +1857,7 @@ definitions:
       meta:altId:
         type: string
         example: '_{TENANT_ID}.schemas.274f17bc5807ff307a046bab1489fb18'
-      $id: 
+      $id:
         type: string
         example: 'https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18'
       version:
@@ -1878,7 +1878,7 @@ definitions:
       title:
         type: string
         example: Tenant Data Schema
-      description: 
+      description:
         type: string
         example: Schema for tenant-specific data
       meta:extensible:
@@ -1904,7 +1904,7 @@ definitions:
       meta:altId:
         type: string
         example: '_{TENANT_ID}.schemas.274f17bc5807ff307a046bab1489fb18__union'
-      $id: 
+      $id:
         type: string
         example: 'https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18__union'
       version:
@@ -1939,7 +1939,7 @@ definitions:
       title:
         type: string
         example: Tenant Data Schema
-      description: 
+      description:
         type: string
         example: Schema for tenant-specific data
       meta:immutableTags:
@@ -1975,7 +1975,7 @@ definitions:
       meta:altId:
         type: string
         example: '_{TENANT_ID}.schemas.274f17bc5807ff307a046bab1489fb18'
-      $id: 
+      $id:
         type: string
         example: 'https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18'
       version:
@@ -2085,7 +2085,7 @@ definitions:
         example: true
       meta:extends:
         type: array
-        items: 
+        items:
           type: string
           example: https://ns.adobe.com/xdm/data/record
       meta:containerId:
@@ -2097,7 +2097,7 @@ definitions:
       $id:
         type: string
         example: 'https://ns.adobe.com/{TENANT_ID}/classes/12345b243d04b5d4f41eaa72a8ba58be'
-      meta:altId: 
+      meta:altId:
         type: string
         example: "_{TENANT_ID}.classes.12345b243d04b5d4f41eaa72a8ba58be"
       version:
@@ -2121,7 +2121,7 @@ definitions:
           xdm:createdClientId:
             type: string
             example: '{CREATED_CLIENT}'
-          xdm:repositoryCreatedBy: 
+          xdm:repositoryCreatedBy:
             type: string
             example: '{CREATED_BY}'
   lookupClassResponse:
@@ -2133,7 +2133,7 @@ definitions:
       title:
         type: string
         example: Tenant Class
-      description: 
+      description:
         type: string
         example: Description of tenant-defined class.
       meta:extensible:
@@ -2159,7 +2159,7 @@ definitions:
       meta:altId:
         type: string
         example: '_{TENANT_ID}.classes.7bc5807ff307a046bab1489fb1812345'
-      $id: 
+      $id:
         type: string
         example: 'https://ns.adobe.com/{TENANT_ID}/classes/7bc5807ff307a046bab1489fb1812345'
       version:
@@ -2236,35 +2236,7 @@ definitions:
       definitions:
         type: object
         description: Attributes of the field group, nested under `properties` and  `_{TENANT_ID}`.
-        properties:
-          loyalty:
-            type: object
-            description: Nested structure under which to include field group properties. For example, in a Loyalty field group, the namespace could be `loyalty`.
-            properties:
-              properties:
-                type: object
-                properties:
-                  '_{TENANT_ID}':
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                        example: object
-                      properties:
-                        type: object
-                        properties:
-                          loyaltyId:
-                            type: object
-                            properties:
-                              title:
-                                type: string
-                                example: loyaltyId
-                              type:
-                                type: string
-                                example: string
-                              description:
-                                type: string
-                                example: Unique loyalty identifier.
+        additionalProperties: true
       allOf:
         type: array
         items:
@@ -2346,8 +2318,8 @@ definitions:
         'repo:lastModifiedDate': 1552668061906
         'xdm:createdClientId': '{CREATED_CLIENT}'
         'xdm:repositoryCreatedBy': '{CREATED_BY}'
-    
-  createFieldGroupResponse:          
+
+  createFieldGroupResponse:
     type: object
     properties:
       type:
@@ -2419,7 +2391,7 @@ definitions:
       $id:
         type: string
         example: 'https://ns.adobe.com/{TENANT_ID}/mixins/477bb01d7125b015b4feba7bccc2e599'
-      meta:altId: 
+      meta:altId:
         type: string
         example: '_{TENANT_ID}.mixins.477bb01d7125b015b4feba7bccc2e599'
       version:
@@ -2443,7 +2415,7 @@ definitions:
           xdm:createdClientId:
             type: string
             example: '{CREATED_CLIENT}'
-          xdm:repositoryCreatedBy: 
+          xdm:repositoryCreatedBy:
             type: string
             example: '{CREATED_BY}'
   lookupFieldGroupResponse:
@@ -2497,7 +2469,7 @@ definitions:
       title:
         type: string
         example: Loyalty Field Group
-      description: 
+      description:
         type: string
         example: Field group to describe members of the Loyalty Program.
       meta:extensible:
@@ -2521,7 +2493,7 @@ definitions:
       meta:altId:
         type: string
         example: '_{TENANT_ID}.mixins.477bb01d7125b015b4feba7bccc2e599'
-      $id: 
+      $id:
         type: string
         example: 'https://ns.adobe.com/{TENANT_ID}/mixins/477bb01d7125b015b4feba7bccc2e599'
       version:
@@ -2599,7 +2571,7 @@ definitions:
                               type:
                                 type: string
                                 example: string
-                              
+
       allOf:
         type: array
         items:
@@ -2735,7 +2707,7 @@ definitions:
         'repo:lastModifiedDate': 1552668061906
         'xdm:createdClientId': '{CREATED_CLIENT}'
         'xdm:repositoryCreatedBy': '{CREATED_BY}'
-      
+
   createDataTypeResponse:
     type: object
     properties:
@@ -2790,7 +2762,7 @@ definitions:
       $id:
         type: string
         example: 'https://ns.adobe.com/{TENANT_ID}/datatypes/24c643f618647344606222c494bd0102'
-      meta:altId: 
+      meta:altId:
         type: string
         example: "_{TENANT_ID}.datatypes.24c643f618647344606222c494bd0102"
       version:
@@ -2814,7 +2786,7 @@ definitions:
           xdm:createdClientId:
             type: string
             example: '{CREATED_CLIENT}'
-          xdm:repositoryCreatedBy: 
+          xdm:repositoryCreatedBy:
             type: string
             example: '{CREATED_BY}'
   lookupDataTypeResponse:
@@ -2871,7 +2843,7 @@ definitions:
       $id:
         type: string
         example: 'https://ns.adobe.com/{TENANT_ID}/datatypes/24c643f618647344606222c494bd0102'
-      meta:altId: 
+      meta:altId:
         type: string
         example: "_{TENANT_ID}.datatypes.24c643f618647344606222c494bd0102"
       version:
@@ -2895,7 +2867,7 @@ definitions:
           xdm:createdClientId:
             type: string
             example: '{CREATED_CLIENT}'
-          xdm:repositoryCreatedBy: 
+          xdm:repositoryCreatedBy:
             type: string
             example: '{CREATED_BY}'
   patchDataType:
@@ -2978,7 +2950,7 @@ definitions:
         type: array
         items:
           type: string
-          example: 'cb509fd6f8ab6304e346905441a34b58a0cd481a'   
+          example: 'cb509fd6f8ab6304e346905441a34b58a0cd481a'
   lookupDescriptorResponse:
     type: object
     properties:
@@ -3006,7 +2978,7 @@ definitions:
         example: Phone
       'xdm:property':
         type: string
-        enum: 
+        enum:
         - xdm:id
         - xdm:code
         example: 'xdm:code'
@@ -3064,7 +3036,7 @@ definitions:
         example: Email
       'xdm:property':
         type: string
-        enum: 
+        enum:
         - xdm:id
         - xdm:code
         example: 'xdm:code'
@@ -3098,7 +3070,7 @@ definitions:
         example: Email
       'xdm:property':
         type: string
-        enum: 
+        enum:
         - xdm:id
         - xdm:code
         example: 'xdm:code'

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -126,8 +126,6 @@ paths:
       - $ref: '#/parameters/accept'
       summary: Retrieve a field group within the specified container by ID.
       operationId: lookupFieldGroup
-      produces:
-        - application/vnd.adobe.xed-id+json
       responses:
         '200':
           description: A successful response returns the details of the field group.
@@ -1504,24 +1502,28 @@ parameters:
     required: true
     type: string
     in: header
+    default: application/json
   accept:
     name: Accept
     description: The desired response format (eg. application/vnd.adobe.xed-full+json; version=1). "Version" is required.
     required: true
     type: string
     in: header
+    default: application/vnd.adobe.xed-full+json; version=1
   acceptListing:
     name: Accept
     description: The desired response format (eg. application/vnd.adobe.xed-id+json). Do not include "version".
     required: true
     type: string
     in: header
+    default: application/vnd.adobe.xed-id+json
   acceptDescriptors:
     name: Accept
     description: Descriptors require unique `Accept` headers using 'xdm' instead of 'xed' (eg. application/vnd.adobe.xdm-id+json)
     required: true
     type: string
     in: header
+    default: application/vnd.adobe.xdm-id+json
   property:
     name: property
     description: A comma-separated list of top-level object properties to be returned in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile` returns only field groups that are compatible with the XDM Individual Profile class.

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -1671,22 +1671,33 @@ definitions:
         items:
           type: object
       classUsage:
-        type: object
-        properties:
-          'https://ns.adobe.com/xdm/context/profile':
-            type: array
-            items:
-              type: object
-              properties:
-                $id:
-                  type: string
-                  example: 'https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18'
-                title:
-                  type: string
-                  example: Tenant Data Schema
-                description:
-                  type: string
-                  example: Schema for tenant-specific data.
+        type: array
+        items:
+          type: object
+          properties:
+            $id:
+              type: string
+              example: 'https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18'
+            title:
+              type: string
+              example: Some Custom Class Name
+            numberOfSchemas:
+              type: integer
+              example: 4
+            schemas:
+              type: array
+              items:
+                type: object
+                properties:
+                  $id:
+                    type: string
+                    example: 'https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18'
+                  title:
+                    type: string
+                    example: Tenant Data Schema
+                  description:
+                    type: string
+                    example: Schema for tenant-specific data.
   listSchemasResponse:
     type: object
     properties:

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -126,6 +126,8 @@ paths:
       - $ref: '#/parameters/accept'
       summary: Retrieve a field group within the specified container by ID.
       operationId: lookupFieldGroup
+      produces:
+        - application/vnd.adobe.xed-full+json; version=1
       responses:
         '200':
           description: A successful response returns the details of the field group.
@@ -310,7 +312,7 @@ paths:
         A lookup request requires the resource's major version be included in the `Accept` header. When supplying the major version, the registry returns the latest minor version automatically.
       operationId: lookupSchema
       produces:
-        - application/vnd.adobe.xed-id+json
+        - application/vnd.adobe.xed-full+json; version=1
       responses:
         '200':
           description: A successful response returns the details of the schema.

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Retrieve a field group within the specified container by ID.
       operationId: lookupFieldGroup
       produces:
-        - application/vnd.adobe.xed-full+json;version=1
+        - application/vnd.adobe.xed-id+json
       responses:
         '200':
           description: A successful response returns the details of the field group.

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Retrieve a field group within the specified container by ID.
       operationId: lookupFieldGroup
       produces:
-        - application/vnd.adobe.xed-full+json; version=1
+        - application/json
       responses:
         '200':
           description: A successful response returns the details of the field group.
@@ -312,7 +312,7 @@ paths:
         A lookup request requires the resource's major version be included in the `Accept` header. When supplying the major version, the registry returns the latest minor version automatically.
       operationId: lookupSchema
       produces:
-        - application/vnd.adobe.xed-full+json; version=1
+        - application/json
       responses:
         '200':
           description: A successful response returns the details of the schema.

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -73,13 +73,21 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns your tenant ID and Schema Registry usage information.
           schema:
             '$ref': '#/definitions/statsResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/{CONTAINER_ID}/fieldgroups':
     get:
@@ -100,13 +108,21 @@ paths:
         - $ref: '#/parameters/start'
         - $ref: '#/parameters/limit'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns all field groups in the specified container.
           schema:
             $ref: '#/definitions/listFieldGroupsResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/{CONTAINER_ID}/fieldgroups/{FIELD_GROUP_ID}':
     get:
@@ -129,15 +145,25 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the field group.
           schema:
             $ref: '#/definitions/lookupFieldGroupResponse'
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The specified `Accept` format/version is not available for this resource.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/fieldgroups':
     post:
@@ -157,13 +183,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/fieldGroupPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: A successful response returns the details of the field group.
           schema:
             $ref: '#/definitions/createFieldGroupResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/fieldgroups/{FIELD_GROUP_ID}':
     put:
@@ -189,13 +223,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/replaceFieldGroupPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the updated field group.
           schema:
             $ref: '#/definitions/updateFieldGroupResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     patch:
       tags:
@@ -224,13 +266,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/patchFieldGroupPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the updated field group.
           schema:
             $ref: '#/definitions/patchFieldGroupResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     delete:
       tags:
@@ -253,12 +303,20 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the field group has been deleted.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '500':
-         description: An internal server error occurred.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: An internal server error occurred.
   '/{CONTAINER_ID}/schemas':
     get:
       tags:
@@ -284,13 +342,21 @@ paths:
         - $ref: '#/parameters/start'
         - $ref: '#/parameters/limit'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of all schemas in the container with format dependent on the `Accept` header.
           schema:
             $ref: '#/definitions/listSchemasResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/{CONTAINER_ID}/schemas/{SCHEMA_ID}':
     get:
@@ -314,17 +380,29 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the schema.
           schema:
             $ref: '#/definitions/lookupSchemaResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The specified `Accept` format/version is not available for this resource.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/schemas':
     post:
@@ -344,13 +422,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/createSchemaPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: A successful response returns the details of the newly created schema.
           schema:
             '$ref': '#/definitions/createSchemaResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/schemas/{SCHEMA_ID}':
     put:
@@ -372,11 +458,19 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/replaceSchemaPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns JSON schema with updated attributes.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     patch:
       tags:
@@ -401,13 +495,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/patchPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns JSON schema with updated attributes.
           schema:
             $ref: '#/definitions/patchSchemaResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
 
     delete:
@@ -427,12 +529,20 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the schema has been deleted.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '500':
-         description: An internal server error occurred.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: An internal server error occurred.
   '/global/behaviors':
     get:
       tags:
@@ -447,6 +557,10 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/acceptListing'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns all behaviors in the global container.
           schema:
@@ -500,6 +614,10 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/accept'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the behavior specified in the request path.
           schema:
@@ -574,13 +692,21 @@ paths:
         - $ref: '#/parameters/start'
         - $ref: '#/parameters/limit'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns all mixins in the specified container.
           schema:
             $ref: '#/definitions/listFieldGroupsResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/{CONTAINER_ID}/mixins/{MIXIN_ID}':
     get:
@@ -600,15 +726,25 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the mixin.
           schema:
             $ref: '#/definitions/lookupFieldGroupResponse'
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The specified `Accept` format/version is not available for this resource.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/mixins':
     post:
@@ -629,13 +765,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/fieldGroupPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: A successful response returns the details of the mixin.
           schema:
             $ref: '#/definitions/createFieldGroupResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/mixins/{MIXIN_ID}':
     put:
@@ -658,11 +802,19 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/replaceFieldGroupPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the updated mixin.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     patch:
       tags:
@@ -688,11 +840,19 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/patchFieldGroupPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the updated mixin.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     delete:
       tags:
@@ -712,12 +872,20 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the mixin has been deleted.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '500':
-         description: An internal server error occurred.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: An internal server error occurred.
   '/{CONTAINER_ID}/classes':
     get:
       tags:
@@ -738,13 +906,21 @@ paths:
         - $ref: '#/parameters/start'
         - $ref: '#/parameters/limit'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of all classes in the container.
           schema:
             $ref: '#/definitions/listClassesResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/{CONTAINER_ID}/classes/{CLASS_ID}':
     get:
@@ -767,15 +943,25 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the class.
           schema:
             $ref: '#/definitions/lookupClassResponse'
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The specified `Accept` format/version is not available for this resource.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/classes':
     post:
@@ -795,13 +981,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/createClassPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: A successful response returns the details of the newly created class.
           schema:
             '$ref': '#/definitions/createClassResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
 
   '/tenant/classes/{CLASS_ID}':
@@ -828,11 +1022,19 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/replaceClassPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the updated class.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     patch:
       tags:
@@ -861,11 +1063,19 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/patchPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the the details of the updated class.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     delete:
       tags:
@@ -888,12 +1098,20 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the resource has been deleted.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '500':
-         description: An internal server error occurred.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: An internal server error occurred.
   '/{CONTAINER_ID}/datatypes':
     get:
       tags:
@@ -913,13 +1131,21 @@ paths:
         - $ref: '#/parameters/start'
         - $ref: '#/parameters/limit'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of all data types in the specified container.
           schema:
             $ref: '#/definitions/listDataTypesResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/{CONTAINER_ID}/datatypes/{DATA_TYPE_ID}':
     get:
@@ -937,15 +1163,25 @@ paths:
       produces:
         - application/json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the data type.
           schema:
             $ref: '#/definitions/lookupDataTypeResponse'
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The specified `Accept` format/version is not available for this resource.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/datatypes':
     post:
@@ -965,13 +1201,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/createDataTypePayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: A successful response returns the details of the newly created data type.
           schema:
             '$ref': '#/definitions/createDataTypeResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/datatypes/{DATA_TYPE_ID}':
     put:
@@ -993,13 +1237,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/replaceDataTypePayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the updated data type.
           schema:
             '$ref': '#/definitions/putDataTypeResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     patch:
       tags:
@@ -1024,13 +1276,21 @@ paths:
         - $ref: '#/parameters/content-type'
         - $ref: '#/parameters/patchDataTypePayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the updated data type.
           schema:
             '$ref': '#/definitions/patchDataTypeResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     delete:
       tags:
@@ -1049,12 +1309,20 @@ paths:
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the class has been deleted.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '500':
-         description: An internal server error occurred.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: An internal server error occurred.
   '/{CONTAINER_ID}/descriptors':
     get:
       tags:
@@ -1104,13 +1372,21 @@ paths:
         in: query
         type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of all existing descriptors, separated by type.
           schema:
             $ref: '#/definitions/listDescriptorsResponse'
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/{CONTAINER_ID}/descriptors/{DESCRIPTOR_ID}':
     get:
@@ -1129,13 +1405,21 @@ paths:
       - $ref: '#/parameters/x-gw-ims-org-id'
       - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the descriptor.
           schema:
             $ref: '#/definitions/lookupDescriptorResponse'
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/descriptors':
     post:
@@ -1156,15 +1440,25 @@ paths:
       - $ref: '#/parameters/content-type'
       - $ref: '#/parameters/descriptorPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: A successful response returns the details of the newly created descriptor.
           schema:
             $ref: '#/definitions/createDescriptorResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
 
   '/tenant/descriptors/{DESCRIPTOR_ID}':
@@ -1192,16 +1486,26 @@ paths:
       - $ref: '#/parameters/content-type'
       - $ref: '#/parameters/descriptorPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: A successful response returns the `@id` of the updated descriptor.
           examples:
             application/json:
               "@id": "0fe5e262d27e986025bef6d33987002d64525efe"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
     delete:
       tags:
@@ -1216,13 +1520,23 @@ paths:
       - $ref: '#/parameters/x-gw-ims-org-id'
       - $ref: '#/parameters/x-sandbox-name'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the descriptor has been deleted.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/unions':
     get:
@@ -1240,13 +1554,21 @@ paths:
         - $ref: '#/parameters/start'
         - $ref: '#/parameters/limit'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a list of all union schemas with format dependent on the `Accept` header.
           schema:
             $ref: '#/definitions/listUnionsResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/tenant/unions/{UNION_ID}':
     get:
@@ -1261,17 +1583,29 @@ paths:
       - $ref: '#/parameters/accept'
       summary: Retrieve a union schema by ID.
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the union.
           schema:
             $ref: '#/definitions/lookupUnionResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The resource is not found.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The specified `Accept` format/version is not available for this resource.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An internal server error occurred.
   '/rpc/export/{RESOURCE_ID}':
     get:
@@ -1290,6 +1624,10 @@ paths:
         in: path
         type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the exported resource and its dependent field groups and data types. The contents of this payload can then be used as the request body in a POST `/rpc/import` call to import the resource to the desired sandbox or IMS Organization.
           schema:
@@ -1322,6 +1660,10 @@ paths:
         schema:
           $ref: '#/definitions/importExportPayload'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns the details of the imported resource, with the appropriate `{TENANT_ID}` applied for the specified IMS Organization.
           schema:
@@ -1347,6 +1689,10 @@ paths:
         in: path
         type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns a sample ingestion file, mapped to the structure of the specified schema.
           schema:
@@ -1388,6 +1734,10 @@ paths:
         required: true
         type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A successful response returns an array of change logs for the specified resource. Each change object provides details on what action was performed to which field(s), the user that made the change, and a timestamp for when the change was committed.
           schema:
@@ -3274,3 +3624,30 @@ definitions:
   profile-person-details:
     type: string
     example: '#/definitions/profile-person-details'
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -2339,35 +2339,7 @@ definitions:
       definitions:
         type: object
         description: Attributes of the field group, nested under `properties` and  `_{TENANT_ID}`.
-        properties:
-          loyalty:
-            type: object
-            description: Nested structure under which to include field group properties. For example, in a Loyalty field group, the namespace could be `loyalty`.
-            properties:
-              properties:
-                type: object
-                properties:
-                  '_{TENANT_ID}':
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                        example: object
-                      properties:
-                        type: object
-                        properties:
-                          loyaltyId:
-                            type: object
-                            properties:
-                              title:
-                                type: string
-                                example: loyaltyId
-                              type:
-                                type: string
-                                example: string
-                              description:
-                                type: string
-                                example: Unique loyalty identifier.
+        additionalProperties: true
       allOf:
         type: array
         items:
@@ -2542,36 +2514,7 @@ definitions:
       definitions:
         type: object
         description: Attributes of the field group, nested under `properties` and  `_{TENANT_ID}`.
-        properties:
-          loyalty:
-            type: object
-            description: Nested structure under which to include field group properties. For example, in a Loyalty field group, the namespace could be `loyalty`.
-            properties:
-              properties:
-                type: object
-                properties:
-                  '_{TENANT_ID}':
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                        example: object
-                      properties:
-                        type: object
-                        properties:
-                          loyaltyLevel:
-                            type: object
-                            properties:
-                              title:
-                                type: string
-                                example: Loyalty Level
-                              description:
-                                type: string
-                                example: Member level within the loyalty program.
-                              type:
-                                type: string
-                                example: string
-
+        additionalProperties: true
       allOf:
         type: array
         items:

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -2286,6 +2286,75 @@ definitions:
         'xdm:repositoryCreatedBy': '{CREATED_BY}'
   updateFieldGroupResponse:
     type: object
+    properties:
+      type:
+        type: string
+        example: object
+      title:
+        type: string
+        example: Loyalty Details
+      description:
+        type: string
+        example: "Field group to describe members of the Loyalty Program."
+      meta:intendedToExtend:
+        type: array
+        items:
+          type: string
+          example: 'https://ns.adobe.com/xdm/context/profile'
+      definitions:
+        type: object
+        description: Attributes of the field group, nested under `properties` and  `_{TENANT_ID}`.
+        additionalProperties: true
+      allOf:
+        type: array
+        items:
+          type: object
+          properties:
+            $ref:
+              type: string
+              example: '#/definitions/loyalty'
+      meta:abstract:
+        type: boolean
+        example: true
+      meta:extensible:
+        type: boolean
+        example: true
+      meta:containerId:
+        type: string
+        example: tenant
+      imsOrg:
+        type: string
+        example: '{IMS_ORG}'
+      $id:
+        type: string
+        example: 'https://ns.adobe.com/{TENANT_ID}/mixins/477bb01d7125b015b4feba7bccc2e599'
+      meta:altId:
+        type: string
+        example: '_{TENANT_ID}.mixins.477bb01d7125b015b4feba7bccc2e599'
+      version:
+        type: string
+        example: '1.0'
+      meta:xdmType:
+        type: string
+        example: object
+      meta:resourceType:
+        type: string
+        example: mixins
+      meta:registryMetadata:
+        type: object
+        properties:
+          repo:createDate:
+            type: integer
+            example: 1552668061906
+          repo:lastModifiedDate:
+            type: integer
+            example: 1552668061906
+          xdm:createdClientId:
+            type: string
+            example: '{CREATED_CLIENT}'
+          xdm:repositoryCreatedBy:
+            type: string
+            example: '{CREATED_BY}'
     example:
       type: object
       title: Loyalty Details

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -102,7 +102,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptFullListing'
+        - $ref: '#/parameters/acceptListing'
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/orderBy'
         - $ref: '#/parameters/start'
@@ -336,7 +336,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptFullListing'
+        - $ref: '#/parameters/acceptListing'
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/orderBy'
         - $ref: '#/parameters/start'
@@ -369,7 +369,7 @@ paths:
       - $ref: '#/parameters/x-api-key'
       - $ref: '#/parameters/x-gw-ims-org-id'
       - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/accept'
+      - $ref: '#/parameters/acceptFull'
       summary: Retrieve a schema within the specified container by ID.
       description: >-
         The response format depends on the `Accept` header sent in the request. The following `Accept` headers are available for this request:<ul><li>`application/vnd.adobe.xed+json; version=1`:  Raw with `$ref` and `allOf` included. Has titles and descriptions.</li><li>`application/vnd.adobe.xed-full+json; version=1`: `$ref` and `allOf` included. Has titles and descriptions.</li><li>`application/vnd.adobe.xed-notext+json; version=1`: Raw with `$ref` and `allOf` included, but with no titles or descriptions</li><li>`application/vnd.adobe.xed-full-notext+json; version=1`:  `$ref` and `allOf` are resolved, with no titles or descriptions.</li><li>`application/vnd.adobe.xed-full-desc+json; version=1`: `$ref` and `allOf` are resolved, with descriptions included.</li></ul>
@@ -900,7 +900,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptFullListing'
+        - $ref: '#/parameters/acceptListing'
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/orderBy'
         - $ref: '#/parameters/start'
@@ -937,7 +937,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/accept'
+        - $ref: '#/parameters/acceptFull'
       summary: Retrieve a class within the specified container by ID.
       operationId: lookupClass
       produces:
@@ -1124,7 +1124,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptFullListing'
+        - $ref: '#/parameters/acceptListing'
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/orderBy'
@@ -1857,6 +1857,13 @@ parameters:
     default: application/json
   accept:
     name: Accept
+    description: The desired response format (eg. application/vnd.adobe.xed+json; version=1). "Version" is required.
+    required: true
+    type: string
+    in: header
+    default: application/vnd.adobe.xed+json; version=1
+  acceptFull:
+    name: Accept
     description: The desired response format (eg. application/vnd.adobe.xed-full+json; version=1). "Version" is required.
     required: true
     type: string
@@ -1864,11 +1871,11 @@ parameters:
     default: application/vnd.adobe.xed-full+json; version=1
   acceptListing:
     name: Accept
-    description: The desired response format (eg. application/vnd.adobe.xed-id+json). Do not include "version".
+    description: The desired response format (eg. application/vnd.adobe.xed+json). Do not include "version".
     required: true
     type: string
     in: header
-    default: application/vnd.adobe.xed-id+json
+    default: application/vnd.adobe.xed+json
   acceptFullListing:
     name: Accept
     description: The desired response format (eg. application/vnd.adobe.xed-full-hidden+json). Do not include "version".
@@ -1876,6 +1883,13 @@ parameters:
     type: string
     in: header
     default: application/vnd.adobe.xed-full-hidden+json
+  acceptListingIdOnly:
+    name: Accept
+    description: The desired response format (eg. application/vnd.adobe.xed-id+json). Do not include "version".
+    required: true
+    type: string
+    in: header
+    default: application/vnd.adobe.xed-id+json
   acceptDescriptors:
     name: Accept
     description: Descriptors require unique `Accept` headers using 'xdm' instead of 'xed' (eg. application/vnd.adobe.xdm-id+json)
@@ -2212,7 +2226,16 @@ definitions:
           example: https://ns.adobe.com/xdm/context/profile
       properties:
         type: object
-        description: All of the attributes of the schema are found under properties.
+        description: properties field only present if we are doing a lookup on a specific schema. All of the attributes of the schema are found under properties.
+      allOf:
+        description: allOf field only present when we are listing schemas.
+        type: array
+        items:
+          type: object
+          properties:
+            "$ref":
+              type: string
+              example: https://ns.adobe.com/xdm/data/record
       meta:altId:
         type: string
         example: '_{TENANT_ID}.schemas.274f17bc5807ff307a046bab1489fb18'
@@ -2506,7 +2529,16 @@ definitions:
           example: https://ns.adobe.com/xdm/data/record
       properties:
         type: object
-        description: All of the attributes of the schema are found under properties.
+        description: properties field only present if we are doing a lookup on a specific class. All of the attributes of the schema are found under properties.
+      allOf:
+        description: allOf field only present when we are listing classes.
+        type: array
+        items:
+          type: object
+          properties:
+            "$ref":
+              type: string
+              example: https://ns.adobe.com/xdm/data/record
       meta:altId:
         type: string
         example: '_{TENANT_ID}.classes.7bc5807ff307a046bab1489fb1812345'
@@ -2866,7 +2898,7 @@ definitions:
         items:
           type: string
           example: https://ns.adobe.com/xdm/context/profile
-      properties:
+      definitions:
         type: object
         description: All of the attributes of the schema are found under properties.
       meta:altId:

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -102,7 +102,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
+        - $ref: '#/parameters/acceptFullListing'
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/orderBy'
         - $ref: '#/parameters/start'
@@ -336,7 +336,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
+        - $ref: '#/parameters/acceptFullListing'
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/orderBy'
         - $ref: '#/parameters/start'
@@ -900,7 +900,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
+        - $ref: '#/parameters/acceptFullListing'
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/orderBy'
         - $ref: '#/parameters/start'
@@ -1124,7 +1124,7 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
+        - $ref: '#/parameters/acceptFullListing'
         - $ref: '#/parameters/authorization'
         - $ref: '#/parameters/property'
         - $ref: '#/parameters/orderBy'
@@ -1869,6 +1869,13 @@ parameters:
     type: string
     in: header
     default: application/vnd.adobe.xed-id+json
+  acceptFullListing:
+    name: Accept
+    description: The desired response format (eg. application/vnd.adobe.xed-full-hidden+json). Do not include "version".
+    required: true
+    type: string
+    in: header
+    default: application/vnd.adobe.xed-full-hidden+json
   acceptDescriptors:
     name: Accept
     description: Descriptors require unique `Accept` headers using 'xdm' instead of 'xed' (eg. application/vnd.adobe.xdm-id+json)
@@ -2058,20 +2065,7 @@ definitions:
       results:
         type: array
         items:
-          type: object
-          properties:
-            title:
-              type: string
-              example: Tenant Data Schema
-            $id:
-              type: string
-              example: 'https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18'
-            meta:altId:
-              type: string
-              example: '_{TENANT_ID}.schemas.274f17bc5807ff307a046bab1489fb18'
-            version:
-              type: string
-              example: '1.1'
+          $ref: '#/definitions/lookupSchemaResponse'
   listUnionsResponse:
     type: object
     properties:
@@ -2388,20 +2382,7 @@ definitions:
       results:
         type: array
         items:
-          type: object
-          properties:
-            title:
-              type: string
-              example: Tenant Class
-            $id:
-              type: string
-              example: 'https://ns.adobe.com/{TENANT_ID}/classes/123457bc5807ff307a046bab1489fb18'
-            meta:altId:
-              type: string
-              example: '_{TENANT_ID}.classes.123457bc5807ff307a046bab1489fb18'
-            version:
-              type: string
-              example: '1.4'
+          $ref: '#/definitions/lookupClassResponse'
   createClass:
     type: object
     properties:
@@ -2572,20 +2553,7 @@ definitions:
       results:
         type: array
         items:
-          type: object
-          properties:
-            title:
-              type: string
-              example: Loyalty Program Field Group
-            $id:
-              type: string
-              example: 'https://ns.adobe.com/{TENANT_ID}/mixins/bce6c11bbe4ad4155dd940c15dfe74e1'
-            meta:altId:
-              type: string
-              example: '_{TENANT_ID}.mixins.bce6c11bbe4ad4155dd940c15dfe74e1'
-            version:
-              type: string
-              example: '1.0'
+          $ref: '#/definitions/lookupFieldGroupResponse'
   createFieldGroup:
     type: object
     properties:
@@ -2968,20 +2936,7 @@ definitions:
       results:
         type: array
         items:
-          type: object
-          properties:
-            title:
-              type: string
-              example: Tenant Data Type
-            $id:
-              type: string
-              example: 'https://ns.adobe.com/{TENANT_ID}/datatypes/f307a046bab1489fb18274f17bc5807f'
-            meta:altId:
-              type: string
-              example: '_{TENANT_ID}.datatypes.f307a046bab1489fb18274f17bc5807f'
-            version:
-              type: string
-              example: '1.0'
+          $ref: '#/definitions/lookupDataTypeResponse'
   createDataType:
     type: object
     properties:

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Retrieve a field group within the specified container by ID.
       operationId: lookupFieldGroup
       produces:
-        - application/json
+        - application/vnd.adobe.xed-full+json;version=1
       responses:
         '200':
           description: A successful response returns the details of the field group.
@@ -312,7 +312,7 @@ paths:
         A lookup request requires the resource's major version be included in the `Accept` header. When supplying the major version, the registry returns the latest minor version automatically.
       operationId: lookupSchema
       produces:
-        - application/json
+        - application/vnd.adobe.xed-id+json
       responses:
         '200':
           description: A successful response returns the details of the schema.

--- a/acpdr/swagger-specs/schema-registry.yaml
+++ b/acpdr/swagger-specs/schema-registry.yaml
@@ -2231,6 +2231,11 @@ definitions:
       meta:resourceType:
         type: string
         example: schemas
+      meta:immutableTags:
+        type: array
+        items:
+          type: string
+          example: union
       meta:registryMetadata:
         type: object
         description: Various metadata related to the schema.

--- a/acpdr/swagger-specs/segmentation.yaml
+++ b/acpdr/swagger-specs/segmentation.yaml
@@ -18,7 +18,7 @@ info:
         - PLATFORM Gateway URL: https://<span>platform.adobe.io/
         - Base path for this API: /data/core/ups
         - Example of a complete path: https://<span>platform.adobe.io/data/core/ups/segment/definitions
-      
+
     - Required headers:
         - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](https://www.adobe.com/go/platform-api-authentication-en).
         - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
@@ -58,7 +58,7 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - name: limit
           in: query
-          description: >- 
+          description: >-
             Limit the number of export jobs returned in the list.
           required: false
           type: integer
@@ -79,13 +79,21 @@ paths:
             - SUCCEEDED
             - FAILED
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A list of the export jobs returned.
           schema:
             $ref: '#/definitions/GetExportJobsResponse'
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     post:
       tags:
@@ -110,7 +118,7 @@ paths:
           type: string
         - in: body
           name: body
-          description: >- 
+          description: >-
             - **fields** - [Optional] Column filters (comma-separated list of columns in dot notation). Limits the data fields to be included in the export to only those provided in this parameter. The same parameter is also available when creating a segment, therefore the fields in the segment may have already been filtered. Omitting this value will result in all fields being included in the exported data.
 
             - **mergePolicy** - [Optional] Specifies the merge policy to govern the exported data. Include this parameter when there are multiple segments being exported. Omitting this value will cause the Export Service to use the merge policy provided by the segmentId or snapshotName.
@@ -139,6 +147,10 @@ paths:
           schema:
             $ref: '#/definitions/CreateExportJobRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The export job has been  successfully created.
           schema:
@@ -148,8 +160,12 @@ paths:
               type: string
               description: The HREF of the export job.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/export/jobs/{EXPORT_JOB_ID}':
     get:
@@ -171,15 +187,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The export job successfully retrieved.
           schema:
             $ref: '#/definitions/ExportJobResponse'
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The export job was not found.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     delete:
       tags:
@@ -200,15 +226,25 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The export job was successfully cancelled.
           schema:
             $ref: '#/definitions/CancelExportJobResponse'
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The export job was not found.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/segment/definitions':
     get:
@@ -260,13 +296,21 @@ paths:
           type: string
           x-example: sort=name:asc,internalId:desc
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A list of Profile segment definitions is returned.
           schema:
             "$ref": "#/definitions/SegmentDefinition"
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     post:
       tags:
@@ -285,13 +329,17 @@ paths:
         - $ref: '#/parameters/content-type'
         - name: x-request-id
           in: header
-          description: >- 
+          description: >-
             A unique ID must be used per request.
           required: false
           type: string
           x-example: jRot0Q3pgFi2lmLecebqHGTfnApAwVnQ
         - $ref: '#/parameters/segment-body'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The segment definition was successfully posted.
           schema:
@@ -301,12 +349,20 @@ paths:
               type: string
               description: The URL of the segment definition.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid segment definition was posted.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '422':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The segment definition already exists. In order to update a segment definition, use the PATCH operation instead.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/segment/definitions/{SEGMENT_ID}':
     get:
@@ -330,15 +386,25 @@ paths:
           x-example: jRot0Q3pgFi2lmLecebqHGTfnApAwVnQ
         - $ref: '#/parameters/segmentId'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The segment definition was successfully returned.
           schema:
             "$ref": "#/definitions/SegmentDefinition"
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The segment definition was not found.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     delete:
       tags:
@@ -361,13 +427,21 @@ paths:
           x-example: jRot0Q3pgFi2lmLecebqHGTfnApAwVnQ
         - $ref: '#/parameters/segmentId'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The segment definition was successfully deleted.
           schema:
             "$ref": "#/definitions/MessageResponse"
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     patch:
       tags:
@@ -394,6 +468,10 @@ paths:
         - $ref: '#/parameters/segmentId'
         - $ref: '#/parameters/segment-body'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The segment definition was successfully updated.
           schema:
@@ -403,10 +481,16 @@ paths:
               type: string
               description: HREF to the segment definition
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The segment definition is invalid.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/segment/definitions/bulk-get':
     post:
@@ -433,10 +517,14 @@ paths:
                 type: array
                 items:
                   type: object
-                example: 
+                example:
                   - id: 54669488-03ab-4e0d-a694-37fe49e32be8
                   - id: c527dc3f-07fe-4b96-be4e-23f38e734ff8
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '207':
           description: The details of each segment definition are returned. The sample response has been truncated to show only the details for the first segment definition.
           schema:
@@ -463,24 +551,32 @@ paths:
         - $ref: '#/parameters/content-type'
         - name: x-request-id
           in: header
-          description: >- 
+          description: >-
             A unique ID must be used per request.
           required: false
           type: string
           x-example: jRot0Q3pgFi2lmLecebqHGTfnApAwVnQ
         - $ref: '#/parameters/segment-body'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The segment definition was successfully converted.
           schema:
             "$ref": "#/definitions/SegmentDefinition"
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: An invalid segment definition was posted.
         '409':
           description: Conflict. An entity with the specified ID already exists in the system.
         '429':
           description: Too many requests. Please try again in a few minutes.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/segment/jobs':
     get:
@@ -511,7 +607,7 @@ paths:
           x-example: inUS
         - name: start
           in: query
-          description: >- 
+          description: >-
             The page offset, as per the created time of the resource.
           required: false
           type: integer
@@ -526,7 +622,7 @@ paths:
           x-example: 10
         - name: status
           in: query
-          description: >- 
+          description: >-
             The job status.
           required: false
           type: string
@@ -535,26 +631,36 @@ paths:
           in: query
           description: >-
             Used to order the segment jobs. Is written in the format [attributeName]:[desc|asc]
-          required: false 
+          required: false
           type: string
           x-example: creationTime:desc
         - name: property
           in: query
           description: >-
             Used to get exact matches within an attribute in the segment job. Is written in the format [arrayTypeAttributeName]~[objectKey]==[value]
-          required: false 
+          required: false
           type: string
           x-example: segments~segmentId==workInCanada
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A list of the segment jobs returned.
           schema:
             $ref: '#/definitions/SegmentJob'
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was an issue reading the segment job.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     post:
       tags:
@@ -570,10 +676,10 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'        
+        - $ref: '#/parameters/content-type'
         - name: x-profile-instance-id
           in: header
-          description: >- 
+          description: >-
             The ID of the Profile Instance. **Example**: `ups`
           required: false
           type: string
@@ -595,19 +701,31 @@ paths:
             items:
               $ref: '#/definitions/SegmentJobRequest'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The segment job request was successfully posted.
           schema:
             $ref: '#/definitions/SegmentJob'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The segment job request could not be posted. Double check your request body content.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '429':
           description: There are too many segmentation jobs in processing at the moment. Try again at a later time.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was an issue reading the segment job.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/segment/jobs/{SEGMENT_JOB_ID}':
     get:
@@ -625,15 +743,25 @@ paths:
         - $ref: '#/parameters/segmentJobId'
         - $ref: '#/parameters/x-request-id'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The segment job request was successfully retrieved.
           schema:
             $ref: '#/definitions/SegmentJob'
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The segment job request was not found.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     delete:
       tags:
@@ -651,15 +779,25 @@ paths:
         - $ref: '#/parameters/x-request-id'
 
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The segment job request has been marked for cancellation.
           schema:
             $ref: '#/definitions/CancelSegmentJobResponse'
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The segment job request was not found.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/segment/jobs/bulk-get':
     post:
@@ -686,10 +824,14 @@ paths:
                 type: array
                 items:
                   type: object
-                example: 
+                example:
                   - id: cc3419d3-0389-47f1-b174-fead6b3c830d
                   - id: c527dc3f-07fe-4b96-be4e-23f38e734ff8
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '207':
           description: The details of each segment jobs is returned. The sample response has been truncated to show only the details for the first segment job.
           schema:
@@ -718,18 +860,22 @@ paths:
         - $ref: '#/parameters/content-type'
         - in: body
           name: body
-          description: >- 
-            - **predicateExpression**: The predicate expression that is to be evaluated. 
-            
+          description: >-
+            - **predicateExpression**: The predicate expression that is to be evaluated.
+
             - **predicateType**: (Default: PQL) The only value that is available to use for this is PQL for now.
-            
+
             - **predicateModel**: (Default: xdm.model.profile) The model against which this predicate is to be evaluated. Please note that 'touchpoint' is not treated as model as it can be associated with any of the models like profile.
-            
+
             - **graphType**: The graph type that you want to get the cluster from. Possible values are "none" (perform no identity stitching) and "pdg" (perform identity stitching based on your private identity graph).
           required: true
           schema:
             $ref: "#/definitions/CreatePreviewRequest"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         201:
           description: The preview job was successfully posted.
           schema:
@@ -739,8 +885,12 @@ paths:
               type: string
               description: The HREF to the profile preview.
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/preview/{PREVIEW_ID}':
     get:
@@ -758,28 +908,38 @@ paths:
         - $ref: '#/parameters/previewId'
         - name: offset
           in: query
-          description: >- 
+          description: >-
             The offset of the page.
           required: false
           type: string
           x-example: offset=10200
         - name: limit
           in: query
-          description: >- 
+          description: >-
             The number of entries that should be present on a page. If not specified, this value will be 1000.
           required: false
           type: integer
           x-example: 100
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: The results of the preview job have been successfully retrieved.
           schema:
             $ref: "#/definitions/PreviewResponse"
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The preview job was not found.
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     delete:
       tags:
@@ -795,15 +955,25 @@ paths:
         - $ref: '#/parameters/x-sandbox-name'
         - $ref: '#/parameters/previewId'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: The preview job was successfully cancelled.
           schema:
             $ref: "#/definitions/MessageResponse"
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The preview job was not found.
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/estimate/{ESTIMATE_ID}':
     get:
@@ -818,17 +988,27 @@ paths:
         - $ref: '#/parameters/x-api-key'
         - $ref: '#/parameters/x-gw-ims-org-id'
         - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/estimateId'      
+        - $ref: '#/parameters/estimateId'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         200:
           description: The estimate job was successfully retrieved.
           schema:
             $ref: "#/definitions/EstimateResponse"
         403:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         404:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The estimate job was not found.
         503:
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/config/schedules':
     get:
@@ -847,15 +1027,25 @@ paths:
       - $ref: '#/parameters/start'
       - $ref: '#/parameters/limit'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: A list of schedules is returned.
           schema:
             $ref: '#/definitions/SchedulesResponse'
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was an issue reading the schedules.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     post:
       tags:
@@ -874,12 +1064,12 @@ paths:
       - $ref: '#/parameters/x-gw-ims-org-id'
       - $ref: '#/parameters/x-sandbox-name'
       - $ref: '#/parameters/content-type'
-      - $ref: '#/parameters/x-request-id' 
+      - $ref: '#/parameters/x-request-id'
       - in: body
         name: body
         description: >-
           - **name**: **(Required)** The name of schedule. Must be a string.
-          - **type**: **(Required)** The job type in string format.  
+          - **type**: **(Required)** The job type in string format.
             - Supported types: `batch_segmentation` and `export`.
           - **properties**: **(Required)** An object containing additional properties related to the schedule.
             - **properties.segments**: **(Required when `type` equals `batch_segmentation`)** Using `["*"]` ensures all segments are included.
@@ -890,17 +1080,29 @@ paths:
         schema:
           "$ref": "#/definitions/ScheduleCreate"
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The schedule was successfully created.
           schema:
             $ref: '#/definitions/Schedule'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The schedule posted is invalid.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was an issue reading schedules.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/config/schedules/{SCHEDULE_ID}':
     get:
@@ -920,15 +1122,25 @@ paths:
       - $ref: '#/parameters/schedule-id'
       - $ref: '#/parameters/x-request-id'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: The schedule was successfully returned.
           schema:
             $ref: '#/definitions/Schedule'
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The schedule was not found.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     patch:
       tags:
@@ -956,17 +1168,29 @@ paths:
           items:
             $ref: '#/definitions/schedulePatchOperation'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: (No content) The schedule was successfully updated.
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The schedule is invalid.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '429':
           description: There are too many schedule update requests processing at the moment. Try again at a later time.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: There was an issue reading the schedule.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
     delete:
       tags:
@@ -983,19 +1207,29 @@ paths:
       - $ref: '#/parameters/schedule-id'
       - $ref: '#/parameters/x-request-id'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '204':
           description: (No content) The schedule was deleted successfully deleted.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Access is forbidden.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The schedule was not found.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: The service is unavailable.
   '/search/namespaces':
       get:
         tags:
           - Segment search
-        summary: Retrieve a list of search count results, queried across all namespaces. 
+        summary: Retrieve a list of search count results, queried across all namespaces.
         operationId: queryNamespace
         produces:
           - application/json
@@ -1006,7 +1240,7 @@ paths:
             required: true
             type: string
             x-example: _xdm.context.segmentdefinition
-          - $ref: '#/parameters/authorization'      
+          - $ref: '#/parameters/authorization'
           - $ref: '#/parameters/x-api-key'
           - $ref: '#/parameters/x-gw-ims-org-id'
           - name: x-ups-search-version
@@ -1023,13 +1257,21 @@ paths:
             type: string
             x-example: name:test
         responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           '200':
             description: Retrieve a list of search counts, per namespace, based on the specified query.
             schema:
               $ref: '#/definitions/SearchNamespaceList'
           '403':
+            schema:
+              $ref: '#/definitions/ErrorResponse'
             description: Access is forbidden.
           '503':
+            schema:
+              $ref: '#/definitions/ErrorResponse'
             description: The service is unavailable.
   '/search/entities':
       get:
@@ -1052,7 +1294,7 @@ paths:
             required: true
             type: string
             x-example: AAMTraits
-          - $ref: '#/parameters/authorization'      
+          - $ref: '#/parameters/authorization'
           - $ref: '#/parameters/x-api-key'
           - $ref: '#/parameters/x-gw-ims-org-id'
           - name: x-ups-search-version
@@ -1087,13 +1329,21 @@ paths:
             type: number
             x-example: 2
         responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           '200':
             description: A paginated list of search results. Folders are shown first, followed by external segments.
             schema:
               $ref: '#/definitions/SearchEntityList'
           '403':
+            schema:
+              $ref: '#/definitions/ErrorResponse'
             description: Access is forbidden.
           '503':
+            schema:
+              $ref: '#/definitions/ErrorResponse'
             description: The service is unavailable.
   '/search/taxonomy':
       get:
@@ -1110,14 +1360,14 @@ paths:
             description: The name of the schema being searched.
             required: true
             type: string
-            x-example: _xdm.context.segmentdefinition      
+            x-example: _xdm.context.segmentdefinition
           - name: namespace
             in: query
             description: namespace
             required: true
             type: string
             x-example: AAMTraits
-          - $ref: '#/parameters/authorization'      
+          - $ref: '#/parameters/authorization'
           - $ref: '#/parameters/x-api-key'
           - $ref: '#/parameters/x-gw-ims-org-id'
           - name: x-ups-search-version
@@ -1129,19 +1379,27 @@ paths:
           - $ref: '#/parameters/x-sandbox-name'
           - name: entityId
             in: query
-            description: The ID of the object you want to get structural information about. 
+            description: The ID of the object you want to get structural information about.
             required: true
             type: string
             x-example: porshe911_id
         responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           '200':
             description: Taxonomic information associated with an entityId.  This returns an array of folders that contain the search object, the first element of the array is the root folder and last element of the array is search object's parent folder.
             schema:
               $ref: '#/definitions/TaxonomySearchObject'
           '403':
+            schema:
+              $ref: '#/definitions/ErrorResponse'
             description: Access is forbidden.
           '503':
-            description: The service is unavailable.                    
+            schema:
+              $ref: '#/definitions/ErrorResponse'
+            description: The service is unavailable.
 
 definitions:
   EstimateResponse:
@@ -1270,9 +1528,9 @@ definitions:
       graphType:
         type: string
         example: pdg
-        enum: 
+        enum:
           - pdg
-          - none 
+          - none
         description: The graph type that you want to get the cluster from. If the value is "pdg", identity stitching will be done based on your private identity graph. If the value is "none", no identity stitching will be done.
   IndividualPreview:
     type: object
@@ -1428,14 +1686,14 @@ definitions:
             additionalProperties:
               type: object
               additionalProperties:
-                type: number 
+                type: number
           segmentedProfileByStatusCounter:
             type: object
             description: The number of segmented profiles by status per segment ID.
             additionalProperties:
               type: object
               additionalProperties:
-                type: number 
+                type: number
         description: Information about the segment job.
       requestId:
         type: string
@@ -1576,19 +1834,19 @@ definitions:
             properties:
               enabled:
                 type: boolean
-                example: true 
-          continuous: 
+                example: true
+          continuous:
             type: object
             properties:
               enable:
                 type: boolean
-                example: false 
+                example: false
           synchronous:
             type: object
             properties:
               enable:
                 type: boolean
-                example: false 
+                example: false
       payloadSchema:
         type: string
       ttlInDays:
@@ -2046,7 +2304,7 @@ definitions:
               type: string
               example: '*'
             description: This field is required if the job type is batch_segmentation. It holds a list of segment definitions which need to be evaluated at the scheduled time. Use `*` to evaluate all segments.
-        description: schedule properties 
+        description: schedule properties
       schedule:
         type: string
         example: 0 0 1 * * ?
@@ -2087,7 +2345,7 @@ definitions:
           description: A list of namespaces and the number of search objects resulting from the search for each namespace.
           items:
             $ref: '#/definitions/SearchNamespaceObject'
-          example: 
+          example:
            - namespace: 'AAMTraits'
              displayName: 'AAMTraits'
              count: 45
@@ -2110,7 +2368,7 @@ definitions:
               example: "Success"
   SearchEntityList:
     type: object
-    properties: 
+    properties:
       entities:
         type: array
         description: A list of namespaces and the number of search objects resulting from the search for each entity.
@@ -2181,7 +2439,7 @@ definitions:
               description: The name of the namespace.
             count:
               type: number
-              description: The number of objects within the namespace.          
+              description: The number of objects within the namespace.
   SearchEntityObject:
     type: object
     properties:
@@ -2211,7 +2469,7 @@ definitions:
         type: string
         example: Under development, targeting east coast millionaires that buy red cars.
         description: A description attached to the search object.
-    description: An individual search result after issuing a full text search.        
+    description: An individual search result after issuing a full text search.
   SearchResultsPageObject:
     type: object
     properties:
@@ -2234,6 +2492,33 @@ definitions:
         format: int32
         example: 10
         description: The total number of search objects on this page.
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
 parameters:
   authorization:
     name: Authorization
@@ -2263,18 +2548,18 @@ parameters:
     required: true
     type: string
     in: header
-  segment-body: 
+  segment-body:
     in: body
     name: body
     description: >-
       - **name**: The name of the segment. This value must be unique.
 
       - **description**: A description of the segment.
-      
+
       - **expression**: The PQL expression of the segment. Contains the PQL type, format, as well as the value of the PQL query.
-      
+
       - **schema**: - The schema class for the segment.
-      
+
       - **ttlInDays**: - A value representing the time to live.
     required: true
     schema:
@@ -2282,7 +2567,7 @@ parameters:
   x-request-id:
     name: x-request-id
     in: header
-    description: >- 
+    description: >-
       An optional header that may be used for debugging purposes when investigating issues with a workflow. The same ID can be used to identify a single request to the service from a flow. A new ID should be created for each request.
     required: false
     type: string
@@ -2323,7 +2608,7 @@ parameters:
       The ID of the preview job.
     required: true
     type: string
-    x-example: MDowOjZkNDQ1NDhjLTQ5YmQtNDI5Mi1hNzMxLTU1NjU4ZGU1MThmNzo0MA== 
+    x-example: MDowOjZkNDQ1NDhjLTQ5YmQtNDI5Mi1hNzMxLTU1NjU4ZGU1MThmNzo0MA==
   estimateId:
     name: ESTIMATE_ID
     in: path
@@ -2331,22 +2616,22 @@ parameters:
       The ID of the estimate job.
     required: true
     type: string
-    x-example: MDowOjZkNDQ1NDhjLTQ5YmQtNDI5Mi1hNzMxLTU1NjU4ZGU1MThmNzo0MA== 
-  start:      
+    x-example: MDowOjZkNDQ1NDhjLTQ5YmQtNDI5Mi1hNzMxLTU1NjU4ZGU1MThmNzo0MA==
+  start:
     name: start
     in: query
     description: >-
       Return results from a specific page offset. For example, `start=3`.
     required: false
     type: integer
-  limit:  
+  limit:
     name: limit
     in: query
     description: >-
       Limit response to a specific number of objects. Must be a positive number. For example, `limit=10`
     required: false
     type: integer
-  schedule-id:  
+  schedule-id:
     name: SCHEDULE_ID
     in: path
     description: >-

--- a/acpdr/swagger-specs/sensei-ml-api.yaml
+++ b/acpdr/swagger-specs/sensei-ml-api.yaml
@@ -4,22 +4,22 @@ info:
   version: "1.0"
   description: >-
     Sensei Machine Learning API provides a mechanism for data scientists to organize and manage ML services from algorithm onboarding through experimentation and to service deployment.
-    
-    
+
+
     Related documentation:
       * [Data Science Workspace documentation](http://www.adobe.com/go/data-science-overview-en)
-      
+
     Visualize API calls with Postman (a free, third-party software):
       * [Sensei Machine Learning API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Sensei%20Machine%20Learning%20API.postman_collection.json)
       * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)
       * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)
-  
-    
-    API paths: 
-      * PLATFORM Gateway URL: https://<span>platform.adobe.io/ 
+
+
+    API paths:
+      * PLATFORM Gateway URL: https://<span>platform.adobe.io/
       * Base path for this API: /data/sensei
       * Example of a complete path: https://<span>platform.adobe.io/data/sensei/engines
-    
+
     Required headers:
       * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
       * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
@@ -33,11 +33,11 @@ tags:
   - name: Engines
     description: >-
       Engines act as an umbrella entity holding all machine learning instances. This is
-      tied to a Docker image, Java archive, or EGG file which contains machine 
+      tied to a Docker image, Java archive, or EGG file which contains machine
       learning logic to train and score a Model.
   - name: MLInstances
     description: >-
-      MLInstances represent the combination of a specific Engine with particular set 
+      MLInstances represent the combination of a specific Engine with particular set
       of configurations. An instance is often use-case specific for a customer or client.
   - name: MLServices
     description: >-
@@ -50,8 +50,8 @@ tags:
       Allows machine learning Model management and registration (Model artifact that is created by the training process).
   - name: Insights
     description: >-
-      Insights contain metrics which are used to empower a 
-      data scientist to evaluate and choose optimal ML Models by displaying 
+      Insights contain metrics which are used to empower a
+      data scientist to evaluate and choose optimal ML Models by displaying
       relevant evaluation metrics.
 paths:
   /engines:
@@ -79,25 +79,45 @@ paths:
         - $ref: '#/parameters/orderbyQueryParam'
         - $ref: '#/parameters/propertyQueryParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: List of Engines
           schema:
             $ref: '#/definitions/EngineListing'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     post:
       tags:
@@ -176,6 +196,10 @@ paths:
             operation
           x-content-type: application/octet-stream
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Creation successful
           headers:
@@ -185,24 +209,44 @@ paths:
           schema:
             $ref: '#/definitions/Engine'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '415':
-          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format. 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format.
         '422':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unprocessable Entity. Client sent a correct request that contained invalid values for one or more parameters.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
 
   /engines/dockerRegistry:
@@ -222,25 +266,45 @@ paths:
       produces:
         - application/vnd.adobe.platform.sensei+json;profile=enginesDockerRegistryInfo.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Docker Registry Information
           schema:
             $ref: '#/definitions/EnginesDockerRegistryInfo'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
 
   /engines/{engineId}:
@@ -259,27 +323,49 @@ paths:
       produces:
         - application/vnd.adobe.platform.sensei+json;profile=engine.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Engine object
           schema:
             $ref: '#/definitions/Engine'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     put:
       tags:
@@ -309,27 +395,49 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Engine object
           schema:
             $ref: '#/definitions/Engine'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     delete:
       tags:
@@ -341,27 +449,49 @@ paths:
         - >-
           application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Engine deleted successfully
           schema:
             $ref: '#/definitions/SenseiApiResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
 
   /mlInstances:
@@ -385,25 +515,45 @@ paths:
         - $ref: '#/parameters/orderbyQueryParam'
         - $ref: '#/parameters/propertyQueryParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: List of MLInstances
           schema:
             $ref: '#/definitions/MLInstanceListing'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     post:
       tags:
@@ -430,6 +580,10 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Creation successful
           headers:
@@ -439,24 +593,44 @@ paths:
           schema:
             $ref: '#/definitions/MLInstance'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '415':
-          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format. 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format.
         '422':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unprocessable Entity. Client sent a correct request that contained invalid values for one or more parameters.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     delete:
       tags:
@@ -474,21 +648,37 @@ paths:
           description: The engineId for which MLinstances should be deleted
           required: true
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Successful operation
           schema:
             $ref: '#/definitions/SenseiApiResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '410':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Resource gone. The requested resource has been permanently removed.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
   '/mlInstances/{mlInstanceId}':
     parameters:
@@ -505,27 +695,49 @@ paths:
       produces:
         - application/vnd.adobe.platform.sensei+json;profile=mlInstance.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: MLInstance object
           schema:
             $ref: '#/definitions/MLInstance'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     put:
       tags:
@@ -550,27 +762,49 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: MLInstance object
           schema:
             $ref: '#/definitions/MLInstance'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     delete:
       tags:
@@ -581,27 +815,49 @@ paths:
         - >-
           application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: MLInstance deleted successfully
           schema:
             $ref: '#/definitions/SenseiApiResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   /experiments:
     parameters:
@@ -624,30 +880,50 @@ paths:
         - $ref: '#/parameters/orderbyQueryParam'
         - $ref: '#/parameters/propertyQueryParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: List of Experiments
           schema:
             $ref: '#/definitions/ExperimentListing'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     post:
       tags:
         - Experiments
-      summary: Create an experiment. 
+      summary: Create an experiment.
       description: ''
       operationId: createExperiment
       consumes:
@@ -668,6 +944,10 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Creation successful
           headers:
@@ -677,24 +957,44 @@ paths:
           schema:
             $ref: '#/definitions/Experiment'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '415':
-          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format. 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format.
         '422':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unprocessable Entity. Client sent a correct request that contained invalid values for one or more parameters.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     delete:
       tags:
@@ -712,21 +1012,37 @@ paths:
           description: The mlInstanceId for which experiments should be deleted
           required: true
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Successful operation
           schema:
             $ref: '#/definitions/SenseiApiResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '410':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Resource gone. The requested resource has been permanently removed.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
   '/experiments/{experimentId}':
     parameters:
@@ -744,27 +1060,49 @@ paths:
       produces:
         - application/vnd.adobe.platform.sensei+json;profile=experiment.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns the Experiment object
           schema:
             $ref: '#/definitions/Experiment'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     put:
       tags:
@@ -789,27 +1127,49 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns the experiment object
           schema:
             $ref: '#/definitions/Experiment'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     delete:
       tags:
@@ -821,27 +1181,49 @@ paths:
         - >-
           application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Experiment deleted successfully
           schema:
             $ref: '#/definitions/SenseiApiResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   '/experiments/{experimentId}/runs':
     parameters:
@@ -865,25 +1247,45 @@ paths:
         - $ref: '#/parameters/orderbyQueryParam'
         - $ref: '#/parameters/propertyQueryParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: List of engines
           schema:
             $ref: '#/definitions/ExperimentRunListing'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     post:
       tags:
@@ -911,6 +1313,10 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Creation successful
           headers:
@@ -922,24 +1328,44 @@ paths:
           schema:
             $ref: '#/definitions/ExperimentRun'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '415':
-          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format. 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format.
         '422':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unprocessable Entity. Client sent a correct request that contained invalid values for one or more parameters.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   '/experiments/{experimentId}/runs/{experimentRunId}':
     parameters:
@@ -959,27 +1385,49 @@ paths:
         - >-
           application/vnd.adobe.platform.sensei+json;profile=experimentRun.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns the run status and info
           schema:
             $ref: '#/definitions/ExperimentRun'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   '/experiments/{experimentId}/runs/{experimentRunId}/status':
     parameters:
@@ -999,27 +1447,49 @@ paths:
         - >-
           application/vnd.adobe.platform.sensei+json;profile=experimentRunStatus.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns the run status and info
           schema:
             $ref: '#/definitions/RunStatus'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   /models:
     parameters:
@@ -1044,27 +1514,49 @@ paths:
         - $ref: '#/parameters/orderbyQueryParam'
         - $ref: '#/parameters/propertyQueryParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: List of Models
           schema:
             $ref: '#/definitions/ModelListing'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     post:
       tags:
@@ -1088,6 +1580,10 @@ paths:
           description: Model object that needs to be created
           x-content-type: application/vnd.adobe.platform.sensei+json;profile=model.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Creation successful
           headers:
@@ -1097,24 +1593,44 @@ paths:
           schema:
             $ref: '#/definitions/Model'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '415':
-          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format. 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format.
         '422':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unprocessable Entity. Client sent a correct request that contained invalid values for one or more parameters.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   '/models/{modelId}':
     parameters:
@@ -1132,27 +1648,49 @@ paths:
       produces:
         - application/vnd.adobe.platform.sensei+json;profile=model.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns the Model object
           schema:
             $ref: '#/definitions/Model'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     put:
       tags:
@@ -1178,27 +1716,49 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns the updated Model object
           schema:
             $ref: '#/definitions/Model'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     delete:
       tags:
@@ -1210,27 +1770,49 @@ paths:
         - >-
           application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Model deleted successfully
           schema:
             $ref: '#/definitions/SenseiApiResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   '/models/{modelId}/artifact':
     parameters:
@@ -1248,28 +1830,50 @@ paths:
       produces:
         - application/octet-stream
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns the binary Model artifact
           schema:
             type: string
             format: binary
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   '/models/{modelId}/transcodings':
     parameters:
@@ -1293,27 +1897,49 @@ paths:
         - $ref: '#/parameters/orderbyQueryParam'
         - $ref: '#/parameters/propertyQueryParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: List of Model Transcodings
           schema:
             $ref: '#/definitions/ModelTranscodingListing'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     post:
       tags:
@@ -1340,6 +1966,10 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Creation successful
           headers:
@@ -1349,24 +1979,44 @@ paths:
           schema:
             $ref: '#/definitions/ModelTranscoding'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '415':
-          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format. 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format.
         '422':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unprocessable Entity. Client sent a correct request that contained invalid values for one or more parameters.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   '/models/{modelId}/transcodings/{modelTranscodingId}':
     parameters:
@@ -1386,27 +2036,49 @@ paths:
         - >-
           application/vnd.adobe.platform.sensei+json;profile=modelTranscoding.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Returns the Model object
           schema:
             $ref: '#/definitions/ModelTranscoding'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   /insights:
     parameters:
@@ -1429,25 +2101,45 @@ paths:
         - $ref: '#/parameters/orderbyQueryParam'
         - $ref: '#/parameters/propertyQueryParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: List of insights
           schema:
             $ref: '#/definitions/InsightListing'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     post:
       tags:
@@ -1472,6 +2164,10 @@ paths:
           required: true
           type: string
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Creation successful
           headers:
@@ -1481,24 +2177,44 @@ paths:
           schema:
             $ref: '#/definitions/Insight'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '415':
-          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format. 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format.
         '422':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unprocessable Entity. Client sent a correct request that contained invalid values for one or more parameters.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   '/insights/{insightId}':
     parameters:
@@ -1516,27 +2232,49 @@ paths:
       produces:
         - application/vnd.adobe.platform.sensei+json;profile=insight.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Insight object
           schema:
             $ref: '#/definitions/Insight'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   '/insights/metrics':
     parameters:
@@ -1554,25 +2292,45 @@ paths:
       produces:
         - application/vnd.adobe.platform.sensei+json;profile=defaultMetricsListing.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: List of metrics
           schema:
             $ref: '#/definitions/DefaultMetricsListing'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
   /mlServices:
     parameters:
@@ -1594,25 +2352,45 @@ paths:
         - $ref: '#/parameters/orderbyQueryParam'
         - $ref: '#/parameters/propertyQueryParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: List of MLServices
           schema:
             $ref: '#/definitions/MLServiceListing'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     post:
       tags:
@@ -1635,6 +2413,10 @@ paths:
             $ref: '#/definitions/MLService'
         - $ref: '#/parameters/authHeaderParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '201':
           description: Creation successful
           headers:
@@ -1644,24 +2426,44 @@ paths:
           schema:
             $ref: '#/definitions/MLService'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '415':
-          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format. 
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+          description: Unsupported Media Type. The server refuses to accept the request because the payload format is in an unsupported format.
         '422':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unprocessable Entity. Client sent a correct request that contained invalid values for one or more parameters.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     delete:
       tags:
@@ -1679,21 +2481,37 @@ paths:
           description: The mlInstanceId for which MLServices should be deleted
           required: true
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: Successful operation
           schema:
             $ref: '#/definitions/SenseiApiResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '410':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Resource gone. The requested resource has been permanently removed.
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
   '/mlServices/{serviceId}':
     parameters:
@@ -1711,27 +2529,49 @@ paths:
         - >-
         - application/vnd.adobe.platform.sensei+json;profile=mlService.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: MLService object
           schema:
             $ref: '#/definitions/MLService'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     put:
       tags:
@@ -1751,27 +2591,49 @@ paths:
             $ref: '#/definitions/MLService'
         - $ref: '#/parameters/ifMatchHeaderParam'
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: MLService object
           schema:
             $ref: '#/definitions/MLService'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
     delete:
       tags:
@@ -1782,27 +2644,49 @@ paths:
         - >-
           application/vnd.adobe.platform.sensei+json;profile=api-response.v1.json
       responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '200':
           description: MLService deleted successfully
           schema:
             $ref: '#/definitions/SenseiApiResponse'
         '400':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Request. The request is malformed.
         '401':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Unauthorized. The request has not been applied because it  lacks valid authentication credentials for the target resource.
         '403':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Forbidden. That combination of arguments is not allowed.
         '404':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Found. The resource the client is looking for isn't there.
         '406':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Not Acceptable. Unacceptable content type. The caller sent an <b>Accept</b> header for a content type which does not exist on the server
         '500':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Internal Server Error. This is an indicator of a server-side error.
         '502':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Bad Gateway. This is an indicator that the search back-end did not send a valid response.
         '503':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Service Unavailable. This is an indicator of a potential server overload.
         '504':
+          schema:
+            $ref: '#/definitions/ErrorResponse'
           description: Gateway Timeout. This is an indicator that the search back-end did not complete a response within an allowed time period.
 
 parameters:
@@ -3084,6 +3968,37 @@ definitions:
         type: string
         readOnly: true
         example: Model specification name must not be empty
+      additionalDetails:
+        type: object
+        additionalProperties:
+          type: string
+  ErrorResponse:
+    type: object
+    properties:
+      timestamp:
+        type: string
+        example: '2019-05-10T22:24:54.914'
+      type:
+        type: string
+        example: 'http://ns.adobe.com/adobecloud/problem/namespacevalidation'
+      status:
+        type: integer
+        example: 404
+      error:
+        type: string
+        example: NAMESPACE_NOT_FOUND
+      detail:
+        type: string
+        example: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
+      description:
+        type: string
+        example: Namespace id not found for given IMS Org 09A55EBC5639E6017F000101@AdobeOrg
+      title:
+        type: string
+        example: Namespace validation
+      report:
+        type: object
+        additionalProperties: true
       additionalDetails:
         type: object
         additionalProperties:


### PR DESCRIPTION
We've just gone through the process of generating an AEP client from the swagger spec and in doing so, we encountered many issues where the specs diverged from the reality of the API, or they were missing important pieces of information required to generate a working client. 

There will likely be further issues, but I feel like we've now solved all those relating to the most common data ingestion use cases (creating datasets, field groups, schemas, connections, dataflows), so it seems like a good time to raise a PR.

Please let me know if you'd like any further explanation for the changes made. 